### PR TITLE
ci: Update Python version to 3.13 in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.13'
           
       - name: Cache pip packages
         uses: actions/cache@v4


### PR DESCRIPTION
Updates the Python version in the GitHub Actions test workflow from 3.10 to 3.13 to align with the Docker environment and ensure consistency across development and CI stages.