### PR TITLE
🐛 Discord heartbeat blocking を asyncio.to_thread() で修正

### DIFF
--- a/.claude/instructions/memory-bank/progress.md
+++ b/.claude/instructions/memory-bank/progress.md
@@ -9,7 +9,7 @@ Claude Code should reference this file when working on related tasks, but doesn'
 
 ## 現在の状態
 
-Sphene Discord BotはXIVAPI v2 Function Callingの検索条件拡張を完了し、ジョブ名・アイテムレベル指定の複合条件検索が可能になりました。全137テストが通過し、テストカバレッジは86%を維持しています。
+Sphene Discord Botは本番環境で発生していたDiscord heartbeat blocking問題を修正しました。`asyncio.to_thread()`により同期ブロッキング呼び出しをイベントループから解放。全137テストが通過し、テストカバレッジは86%を維持しています。
 
 ### 動作している機能
 
@@ -131,6 +131,12 @@ Sphene Discord BotはXIVAPI v2 Function Callingの検索条件拡張を完了し
    - **状態**: 完全に解決
    - **対応**: `import time`を追加、API再試行ロジックが正常動作
 
+### 🟢 解決済み(2026/2)
+
+1. ✅ **Discord Heartbeat Blocking** - 同期OpenAI API呼び出しによるイベントループブロック
+   - **状態**: 完全に解決
+   - **対応**: `asyncio.to_thread()`で`process_conversation()`と`translate_text()`のブロッキング呼び出しをスレッドプールに退避
+
 ### 🟡 継続中の課題
 
 1. **API制限対応**
@@ -154,6 +160,7 @@ Sphene Discord BotはXIVAPI v2 Function Callingの検索条件拡張を完了し
 
 | 日付 | 決定事項 | 理由 |
 |------|----------|------|
+| 2026/2 | Discord heartbeat blocking修正(asyncio.to_thread) | 本番WebSocket切断の解消 |
 | 2026/2 | XIVAPI検索条件拡張(ジョブ・IL対応) | 複合条件検索の実現 |
 | 2025/12/7 | 包括的コードリファクタリング | 保守性・セキュリティ・品質改善 |
 | 2025/12/7 | エラーメッセージ情報漏洩対策 | セキュリティリスク低減 |

--- a/bot/events.py
+++ b/bot/events.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import discord
 from discord import app_commands
 from discord.ext import commands  # commands をインポート
@@ -98,9 +100,9 @@ async def process_conversation(
         logger.info(
             f"画像付きメッセージを処理: ユーザーID {user_id}, 画像数 {len(images)}"
         )
-        answer = api.input_message(question, images)
+        answer = await asyncio.to_thread(api.input_message, question, images)
     else:
-        answer = api.input_message(question)
+        answer = await asyncio.to_thread(api.input_message, question)
 
     if answer:
         if is_reply:

--- a/utils/text_utils.py
+++ b/utils/text_utils.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import config
 from ai.client import client as aiclient
 from log_utils.logger import logger
@@ -51,13 +53,16 @@ async def translate_text(text: str, target_language: str = "english") -> str | N
     try:
         logger.info(f"{config_data['log_prefix']}翻訳リクエスト: {truncate_text(text)}")
 
-        result = aiclient.chat.completions.create(
-            model=config.OPENAI_MODEL,
-            messages=[
-                {"role": "system", "content": config_data["system_prompt"]},
-                {"role": "user", "content": text},
-            ],
-        )
+        def _sync_translate():
+            return aiclient.chat.completions.create(
+                model=config.OPENAI_MODEL,
+                messages=[
+                    {"role": "system", "content": config_data["system_prompt"]},
+                    {"role": "user", "content": text},
+                ],
+            )
+
+        result = await asyncio.to_thread(_sync_translate)
 
         translated_text = result.choices[0].message.content
         if translated_text:


### PR DESCRIPTION
## Summary

- 本番環境で同期 OpenAI API 呼び出しが asyncio イベントループをブロックし、Discord heartbeat が 10-20 秒以上送信できず WebSocket 切断が繰り返し発生していた問題を修正
- `asyncio.to_thread()` で同期ブロッキング呼び出しをスレッドプールに退避（2ファイル・約10行の最小限変更）
- ネストされた全ブロッキング操作（OpenAI API・XIVAPI・requests・time.sleep）を自動的にイベントループから解放

## Changes

| ファイル | 変更内容 |
|---|---|
| `bot/events.py` | `process_conversation()` 内の `api.input_message()` を `await asyncio.to_thread()` でラップ |
| `utils/text_utils.py` | `translate_text()` 内の同期 OpenAI 呼び出しを `await asyncio.to_thread()` でラップ |
| `.claude/instructions/memory-bank/` | activeContext.md, progress.md を更新 |

## Test plan

- [x] `python -m pytest` - 全137テストパス
- [x] `mypy .` - 新しい型エラーなし
- [ ] 本番デプロイ後、ログで heartbeat blocked 警告が出ないことを確認
- [ ] 長時間の API 応答中にボットが切断されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)