### PR TITLE
🔧 デプロイ対象を deployment.yaml から sphene.yaml に変更

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,13 +205,13 @@ jobs:
           path: infra
           token: ${{ secrets.PAT_TOKEN }}
           
-      - name: Update deployment.yaml with new image tag
+      - name: Update sphene.yaml with new image tag
         run: |
           cd infra
           IMAGE_TAG=${{ steps.extract-tag.outputs.IMAGE_TAG }}
-          DEPLOYMENT_FILE="environments/prod/deployment.yaml"
-          
-          # Replace the image tag in deployment.yaml
+          DEPLOYMENT_FILE="environments/prod/sphene.yaml"
+
+          # Replace the image tag in sphene.yaml
           sed -i -e "s|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:.*|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${IMAGE_TAG}|g" $DEPLOYMENT_FILE
           
 


### PR DESCRIPTION
## Summary
- ビルドワークフローのイメージタグ更新対象ファイルを `deployment.yaml` → `sphene.yaml` に変更
- sphene-infra リポジトリのファイル構成に合わせた修正

## Test plan
- [ ] mainブランチへのpush時にビルドワークフローが正常に動作すること
- [ ] sphene-infraリポジトリに対して `sphene.yaml` のイメージタグが更新されたPRが作成されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)