### PR TITLE
Fix: Split long messages to avoid Discord 2000 char limit

### DIFF
--- a/tests/test_utils/test_text_utils.py
+++ b/tests/test_utils/test_text_utils.py
@@ -120,3 +120,50 @@ async def test_translate_to_japanese_error(mock_aiclient: MagicMock) -> None:
 
     # アサーション
     assert result is None
+
+def test_split_message_short() -> None:
+    """短いメッセージは分割されないこと"""
+    from utils.text_utils import split_message
+    text = "Short message"
+    chunks = split_message(text)
+    assert len(chunks) == 1
+    assert chunks[0] == text
+
+
+def test_split_message_long() -> None:
+    """長いメッセージは指定長で分割されること"""
+    from utils.text_utils import split_message
+    # max_length=10 for easy testing
+    text = "123456789012345"
+    chunks = split_message(text, max_length=10)
+    assert len(chunks) == 2
+    assert chunks[0] == "1234567890"
+    assert chunks[1] == "12345"
+
+
+def test_split_message_with_newlines() -> None:
+    """改行がある場合は改行で分割されること"""
+    from utils.text_utils import split_message
+    text = "Line 1\nLine 2\nLine 3"
+    # "Line 1" is 6 chars. + newline = 7.
+    # max_length=10. It should include "Line 1".
+    chunks = split_message(text, max_length=10)
+    # Expected behavior:
+    # 1. "Line 1" (len 6) found \n at 6.
+    # 2. "Line 2" (len 6) found \n at 6.
+    # 3. "Line 3"
+    assert len(chunks) == 3
+    assert chunks[0] == "Line 1"
+    assert chunks[1] == "Line 2"
+    assert chunks[2] == "Line 3"
+
+
+def test_split_message_long_no_newlines() -> None:
+    """改行がない長いメッセージは強制分割されること"""
+    from utils.text_utils import split_message
+    text = "a" * 25
+    chunks = split_message(text, max_length=10)
+    assert len(chunks) == 3
+    assert chunks[0] == "a" * 10
+    assert chunks[1] == "a" * 10
+    assert chunks[2] == "a" * 5

--- a/utils/text_utils.py
+++ b/utils/text_utils.py
@@ -23,6 +23,43 @@ def truncate_text(text: str, max_length: int = PREVIEW_LENGTH) -> str:
     return text[:max_length] + "..." if len(text) > max_length else text
 
 
+def split_message(text: str, max_length: int = 1900) -> list[str]:
+    """テキストをDiscordのメッセージ制限に合わせて分割する
+
+    Args:
+        text: 分割するテキスト
+        max_length: 1メッセージの最大文字数（デフォルトは安全マージンを取って1900）
+
+    Returns:
+        list[str]: 分割されたテキストのリスト
+    """
+    if len(text) <= max_length:
+        return [text]
+
+    chunks = []
+    while text:
+        if len(text) <= max_length:
+            chunks.append(text)
+            break
+
+        # 制限内で最後の改行を探す
+        split_index = text.rfind("\n", 0, max_length)
+
+        if split_index == -1:
+            # 改行が見つからない場合は強制的に分割
+            split_index = max_length
+
+        chunks.append(text[:split_index])
+        # 次のチャンクは改行の次から開始（ただし先頭の空白は削除しない方がコードブロック等で安全かも）
+        # ただし、split_indexが改行の場合、その改行は含めないようにする
+        if text[split_index] == "\n":
+             text = text[split_index + 1:]
+        else:
+             text = text[split_index:]
+    
+    return chunks
+
+
 async def translate_text(text: str, target_language: str = "english") -> str | None:
     """テキストを指定された言語に翻訳する
 


### PR DESCRIPTION
Implements message splitting to handle Discord's 2000 character limit per message.

- Added `split_message` utility in `utils/text_utils.py`.
- Updated `process_conversation` and `send_translation_response` in `bot/events.py` to send split messages.
- Added unit tests.