### PR TITLE
🔧 GitOpsリポジトリのデプロイ先パスを更新

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,7 +209,7 @@ jobs:
         run: |
           cd infra
           IMAGE_TAG=${{ steps.extract-tag.outputs.IMAGE_TAG }}
-          DEPLOYMENT_FILE="environments/prod/sphene.yaml"
+          DEPLOYMENT_FILE="discord-bot/sphene/app.yaml"
 
           # Replace the image tag in sphene.yaml
           sed -i -e "s|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:.*|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${IMAGE_TAG}|g" $DEPLOYMENT_FILE


### PR DESCRIPTION
<!--
GitHub Copilot コードレビューへの指示： このリポジトリのプルリクエストをレビューしてコメントする場合には日本語で記載してください。
-->

## Summary
- sphene-infraのディレクトリ構成変更に追従し、CIのデプロイ先ファイルパスを更新
- `environments/prod/sphene.yaml` → `discord-bot/sphene/app.yaml`

## Test plan
- [ ] mainにマージ後、CIビルドが正常に動作しinfraリポジトリへのPRが作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)