### PR TITLE
feat: Vertex AI（Gemini）対応のマルチプロバイダー化

### DIFF
--- a/.claude/instructions/memory-bank/activeContext.md
+++ b/.claude/instructions/memory-bank/activeContext.md
@@ -5,10 +5,21 @@ applyTo: "**"
 
 ## Current State (2026/2)
 
-- 全テスト通過、カバレッジ86%
+- 全テスト通過（242件）
 - Discord heartbeat blocking修正済み（`asyncio.to_thread()`）
+- Vertex AI OpenAI互換API対応済み（`AI_PROVIDER`環境変数で切替可能）
 
 ## Recent Changes
+
+### 2026/2: Vertex AI OpenAI互換API対応
+
+`AI_PROVIDER`環境変数（`openai`/`vertex_ai`）でプロバイダーを切り替え可能にした。
+
+- `ai/client.py`: シングルトン`client`を廃止、`get_client()`関数に統一。Vertex AI選択時はGCEのWorkload Identity認証（`google.auth.default()`）でトークンを自動取得・リフレッシュ。
+- `config.py`: `AI_PROVIDER`, `VERTEX_AI_PROJECT_ID`, `VERTEX_AI_LOCATION`環境変数を追加。
+- `ai/conversation.py`, `utils/text_utils.py`: クライアント参照を`get_client()`に変更。
+- `pyproject.toml`: `google-auth`を明示的依存に追加。
+- OpenAI互換APIのため、`tools.py`のツール定義やAPIコールパラメータは変更不要。
 
 ### 2026/2: S3廃止 + Firestore移行
 AWS依存（boto3）を完全削除し、GCPベース（google-cloud-firestore）に一本化。
@@ -40,6 +51,7 @@ requirements.txt/requirements-dev.txt → pyproject.toml + uv.lock。pytest.ini 
 | 2026/2 | システムプロンプトはローカルのみ | k8s configmapマウントで十分 |
 | 2026/2 | `asyncio.to_thread()`で最小修正 | 2ファイル10行で全ブロッキングポイントをカバー。フルasync化は中期候補 |
 | 2026/2 | XIVAPI全パラメータにデフォルト値 | `func(**arguments)`動的呼び出しとの後方互換性維持 |
+| 2026/2 | Vertex AI OpenAI互換API対応 | GCP一本化方針。Workload Identity認証でAPIキー管理不要。`AI_PROVIDER`で切替可能 |
 
 ## Open Issues
 

--- a/.claude/instructions/memory-bank/progress.md
+++ b/.claude/instructions/memory-bank/progress.md
@@ -14,6 +14,7 @@ applyTo: "**"
 - チャンネル管理（全体/限定モード、追加/削除）
 - ストレージ: ローカル/Firestore選択（システムプロンプトはローカルのみ）
 - デプロイ: ローカル/Docker/Kubernetes
+- Vertex AI OpenAI互換API対応: `AI_PROVIDER`環境変数でOpenAI/Vertex AI切替、Workload Identity自動認証
 
 ## TODO
 

--- a/.env.sample
+++ b/.env.sample
@@ -4,6 +4,14 @@ BOT_NAME=スフェーン
 COMMAND_GROUP_NAME=sphene
 OPENAI_MODEL=gpt-4o-mini
 
+# AIプロバイダー設定: openai または vertex_ai
+AI_PROVIDER=openai
+
+# Vertex AI設定（AI_PROVIDER=vertex_ai の場合に使用）
+# VERTEX_AI_PROJECT_ID=your-gcp-project-id  # 未設定の場合はGCEメタデータから自動取得
+# VERTEX_AI_LOCATION=asia-northeast1
+# OPENAI_MODEL=google/gemini-2.5-flash
+
 # システムプロンプトの設定
 SYSTEM_PROMPT_FILENAME=system.txt
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,35 @@
 <!--
 GitHub Copilot コードレビューへの指示： このリポジトリのプルリクエストをレビューしてコメントする場合には日本語で記載してください。
 -->
+
+## 概要
+
+<!-- この変更の目的・背景を簡潔に -->
+
+## 変更内容
+
+<!-- 主な変更点を箇条書きで -->
+
+-
+
+## 影響範囲
+
+<!-- 変更が影響するモジュール・機能にチェック -->
+
+- [ ] AI (client / conversation / tools)
+- [ ] Bot (commands / events / discord_bot)
+- [ ] XIVAPI
+- [ ] Utils (text_utils / channel_config / firestore)
+- [ ] Config / 環境変数
+- [ ] 依存パッケージ (pyproject.toml)
+- [ ] Docker / CI
+
+## テスト
+
+- [ ] `uv run python -m pytest` 全件パス
+- [ ] `uv run mypy .` 型チェックパス
+- [ ] カバレッジ 86% 以上を維持
+
+## 補足
+
+<!-- スクリーンショット、参考リンク、レビュアーへの注意点など（任意） -->

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Spheneは、OpenAI APIを活用した会話機能を持つ、シンプルでパ�
 
 ## ✨ 主な機能
 
-- 💬 OpenAIのGPT-4o-miniを使用した高度な会話機能
+- 💬 OpenAI / Vertex AI（Gemini）対応のマルチプロバイダー会話機能
 - 📸 画像処理対応のマルチモーダル会話
 - 👋 メンション、名前呼び、リプライによる柔軟な反応
 - 🌐 国旗リアクションによる自動翻訳機能（🇺🇸 英語 / 🇯🇵 日本語）
@@ -26,7 +26,15 @@ OPENAI_API_KEY=your_openai_api_key
 DISCORD_TOKEN=your_discord_bot_token
 BOT_NAME=スフェーン  # ボットの呼び名（デフォルト: スフェーン）
 COMMAND_GROUP_NAME=sphene  # コマンドグループ名（デフォルト: sphene）
-OPENAI_MODEL=gpt-4o-mini  # 使用するOpenAIのモデル
+OPENAI_MODEL=gpt-4o-mini  # 使用するモデル
+
+# AIプロバイダー設定: openai または vertex_ai
+AI_PROVIDER=openai
+
+# Vertex AI設定（AI_PROVIDER=vertex_ai の場合に使用）
+# VERTEX_AI_PROJECT_ID=your-gcp-project-id  # 未設定の場合はGCEメタデータから自動取得
+# VERTEX_AI_LOCATION=asia-northeast1
+# OPENAI_MODEL=google/gemini-2.5-flash
 
 # システムプロンプトの設定
 SYSTEM_PROMPT_FILENAME=system.txt
@@ -146,7 +154,7 @@ kubectl create secret docker-registry regcred --docker-server=ghcr.io --docker-u
 ├── README.md             # このファイル
 ├── ai/                   # AI関連機能
 │   ├── __init__.py
-│   ├── client.py         # OpenAI API クライアント
+│   ├── client.py         # AIクライアント（OpenAI / Vertex AI）
 │   ├── conversation.py   # 会話管理ロジック
 │   └── tools.py          # Function Callingツール定義
 ├── bot/                  # Discordボット機能
@@ -187,6 +195,8 @@ kubectl create secret docker-registry regcred --docker-server=ghcr.io --docker-u
 - uv - パッケージ管理・仮想環境管理
 - discord.py - Discordボットフレームワーク
 - OpenAI API - GPT-4o-mini会話モデル（マルチモーダル対応）
+- Google Vertex AI - Gemini等のモデルにOpenAI互換APIで接続（GCE Workload Identity対応）
+- google-auth - GCP認証（Vertex AI利用時）
 - Docker - コンテナ化
 - Kubernetes - オプショナルデプロイ環境
 - Cloud Firestore (オプション) - チャンネル設定のリモートストレージ
@@ -213,7 +223,7 @@ kubectl create secret docker-registry regcred --docker-server=ghcr.io --docker-u
 
 ✅ **AIチャット機能**
 
-- GPT-4o-miniモデルとの対話
+- マルチプロバイダー対応（OpenAI / Vertex AI）
 - マルチモーダル対応（画像処理）
 - 会話履歴の管理
 - 会話タイムアウト（30分）
@@ -240,7 +250,6 @@ kubectl create secret docker-registry regcred --docker-server=ghcr.io --docker-u
 - 使用統計の収集と分析
 - パフォーマンス最適化
 - モニタリングとアラート機能
-- 複数のAIモデル選択オプション
 
 ## 🔒 セキュリティ情報
 

--- a/ai/client.py
+++ b/ai/client.py
@@ -1,27 +1,97 @@
+from __future__ import annotations
+
+from typing import Any
+
 from openai import OpenAI
 
 import config
 from log_utils.logger import logger
 
+_client: OpenAI | None = None
+_credentials: Any = None
 
-# OpenAIクライアントの初期化
-def create_client() -> OpenAI:
-    """OpenAIのクライアントインスタンスを作成する
+
+def _create_openai_client() -> OpenAI:
+    """OpenAI APIクライアントを作成する"""
+    logger.info("OpenAIクライアントを初期化しています")
+    return OpenAI(api_key=config.OPENAI_API_KEY)
+
+
+def _get_vertex_ai_client() -> OpenAI:
+    """Vertex AI OpenAI互換クライアントを取得する
+
+    GCEのWorkload Identityを利用して自動認証する。
+    トークンの有効期限切れ時は自動的にリフレッシュする。
 
     Returns:
-        OpenAI: OpenAIのクライアントインスタンス
+        OpenAI: Vertex AI OpenAI互換クライアント
+    """
+    global _client, _credentials
+
+    import google.auth
+    from google.auth.transport.requests import Request
+
+    # 認証情報の初期化
+    if _credentials is None:
+        logger.info("Vertex AI用の認証情報を取得しています")
+        scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+        _credentials, project = google.auth.default(scopes=scopes)
+        # プロジェクトIDが未設定の場合は自動取得した値を使用
+        if not config.VERTEX_AI_PROJECT_ID:
+            config.VERTEX_AI_PROJECT_ID = project or ""
+
+    # トークンのリフレッシュ
+    if not _credentials.valid:
+        logger.debug("認証トークンをリフレッシュしています")
+        _credentials.refresh(Request())
+
+    location = config.VERTEX_AI_LOCATION
+    project_id = config.VERTEX_AI_PROJECT_ID
+    base_url = (
+        f"https://{location}-aiplatform.googleapis.com/v1beta1"
+        f"/projects/{project_id}/locations/{location}/endpoints/openapi"
+    )
+
+    if _client is None:
+        logger.info(f"Vertex AIクライアントを初期化しています（リージョン: {location}）")
+        _client = OpenAI(api_key=_credentials.token, base_url=base_url)
+    else:
+        # トークンだけ更新（リフレッシュ済み）
+        _client.api_key = _credentials.token
+
+    return _client
+
+
+def get_client() -> OpenAI:
+    """AIプロバイダーに応じたOpenAIクライアントを取得する
+
+    AI_PROVIDER環境変数に基づいてOpenAIまたはVertex AIクライアントを返す。
+    OpenAIの場合はシングルトン、Vertex AIの場合はトークン自動リフレッシュ付き。
+
+    Returns:
+        OpenAI: クライアントインスタンス
 
     Raises:
         RuntimeError: クライアント初期化時にエラーが発生した場合
     """
-    logger.info("OpenAIクライアントを初期化しています")
+    global _client
+
     try:
-        return OpenAI(api_key=config.OPENAI_API_KEY)
+        if config.AI_PROVIDER == "vertex_ai":
+            return _get_vertex_ai_client()
+
+        # OpenAI（デフォルト）
+        if _client is None:
+            _client = _create_openai_client()
+        return _client
     except Exception as e:
-        error_msg = f"OpenAIクライアントの初期化に失敗しました: {str(e)}"
+        error_msg = f"AIクライアントの初期化に失敗しました: {str(e)}"
         logger.error(error_msg, exc_info=True)
         raise RuntimeError(error_msg) from e
 
 
-# グローバルなクライアントインスタンス
-client = create_client()
+def reset_client() -> None:
+    """クライアントの状態をリセットする（テスト用）"""
+    global _client, _credentials
+    _client = None
+    _credentials = None

--- a/ai/conversation.py
+++ b/ai/conversation.py
@@ -32,7 +32,7 @@ from openai.types.chat import (
     ChatCompletionToolMessageParam,
 )
 
-from ai.client import client as aiclient
+from ai.client import get_client
 from config import (
     OPENAI_MODEL,
     SYSTEM_PROMPT_FILENAME,
@@ -379,7 +379,7 @@ class Sphene:
             OpenAI API関連の例外は呼び出し元に伝播する
         """
         for round_num in range(MAX_TOOL_CALL_ROUNDS + 1):
-            result = aiclient.chat.completions.create(
+            result = get_client().chat.completions.create(
                 model=OPENAI_MODEL,
                 messages=self.input_list,
                 tools=TOOL_DEFINITIONS,

--- a/config.py
+++ b/config.py
@@ -7,12 +7,20 @@ load_dotenv()
 # ログレベル設定（デフォルトはINFO）
 LOG_LEVEL: str = str(os.getenv("LOG_LEVEL", "INFO"))
 
-OPENAI_API_KEY: str = str(os.getenv("OPENAI_API_KEY"))
+# AIプロバイダー設定（"openai" または "vertex_ai"）
+AI_PROVIDER: str = os.getenv("AI_PROVIDER", "openai")
+
+OPENAI_API_KEY: str = os.getenv("OPENAI_API_KEY", "")
+OPENAI_MODEL: str = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+
+# Vertex AI設定（AI_PROVIDER=vertex_ai の場合に使用）
+VERTEX_AI_PROJECT_ID: str = os.getenv("VERTEX_AI_PROJECT_ID", "")
+VERTEX_AI_LOCATION: str = os.getenv("VERTEX_AI_LOCATION", "asia-northeast1")
+
 DISCORD_TOKEN: str = str(os.getenv("DISCORD_TOKEN"))
 BOT_NAME: str = str(os.getenv("BOT_NAME", "アサヒ"))
 COMMAND_GROUP_NAME: str = str(os.getenv("COMMAND_GROUP_NAME", "asahi"))
 SYSTEM_PROMPT_FILENAME: str = str(os.getenv("SYSTEM_PROMPT_FILENAME", "system.txt"))
-OPENAI_MODEL: str = str(os.getenv("OPENAI_MODEL", "gpt-4o-mini"))
 
 # チャンネル設定の保存場所設定（local または firestore）
 CHANNEL_CONFIG_STORAGE_TYPE: str = str(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "openai",
     "discord.py>=2.0.0",
     "python-dotenv",
+    "google-auth",
     "google-cloud-firestore",
     "requests",
     "httpx",

--- a/tests/test_ai/test_client.py
+++ b/tests/test_ai/test_client.py
@@ -1,74 +1,188 @@
 """ai/client.pyのテスト"""
 
-import os
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 import config
-from ai.client import create_client
+from ai.client import get_client, reset_client
 
 
-def test_create_client(mock_env_vars: dict[str, str]) -> None:
-    """OpenAIクライアント作成が正しく行われることをテスト"""
-    with patch("ai.client.OpenAI") as mock_openai:
-        mock_client = MagicMock()
-        mock_openai.return_value = mock_client
-
-        client = create_client()
-
-        # OpenAIクライアントが正しく作成されたか
-        mock_openai.assert_called_once()
-        # 環境変数のAPIキーが使用されたか
-        mock_openai.assert_called_with(api_key=config.OPENAI_API_KEY)
-        # 返されたクライアントは正しいか
-        assert client == mock_client
+@pytest.fixture(autouse=True)
+def _reset_client_state() -> None:
+    """各テスト前にクライアントの状態をリセット"""
+    reset_client()
 
 
-def test_create_client_with_invalid_api_key() -> None:
-    """APIキーが無効な場合のテスト"""
-    with patch("ai.client.OpenAI") as mock_openai, patch.dict(
-        os.environ, {"OPENAI_API_KEY": ""}, clear=True
-    ):
-        # configの再読み込みをシミュレート
-        with patch.object(config, "OPENAI_API_KEY", ""):
-            # APIキーが無効でもクライアントは作成される (実際の検証はAPI呼び出し時)
-            create_client()
+class TestOpenAIProvider:
+    """AI_PROVIDER=openai のテスト"""
+
+    def test_get_client_creates_openai_client(
+        self, mock_env_vars: dict[str, str]
+    ) -> None:
+        """OpenAIクライアントが正しく作成されることをテスト"""
+        with patch("ai.client.OpenAI") as mock_openai, patch.object(
+            config, "AI_PROVIDER", "openai"
+        ):
+            mock_client = MagicMock()
+            mock_openai.return_value = mock_client
+
+            client = get_client()
+
+            mock_openai.assert_called_once_with(api_key=config.OPENAI_API_KEY)
+            assert client == mock_client
+
+    def test_get_client_returns_singleton(
+        self, mock_env_vars: dict[str, str]
+    ) -> None:
+        """同じインスタンスが返されることをテスト（シングルトン）"""
+        with patch("ai.client.OpenAI") as mock_openai, patch.object(
+            config, "AI_PROVIDER", "openai"
+        ):
+            mock_client = MagicMock()
+            mock_openai.return_value = mock_client
+
+            client1 = get_client()
+            client2 = get_client()
+
             mock_openai.assert_called_once()
-            # 空のAPIキーでも呼び出されるはず
-            mock_openai.assert_called_with(api_key="")
+            assert client1 is client2
+
+    def test_get_client_with_empty_api_key(self) -> None:
+        """APIキーが空でもクライアントが作成されることをテスト"""
+        with patch("ai.client.OpenAI") as mock_openai, patch.object(
+            config, "AI_PROVIDER", "openai"
+        ), patch.object(config, "OPENAI_API_KEY", ""):
+            get_client()
+            mock_openai.assert_called_once_with(api_key="")
+
+    def test_get_client_with_api_error(self) -> None:
+        """クライアント作成時にエラーが発生した場合のテスト"""
+        with patch("ai.client.OpenAI") as mock_openai, patch.object(
+            config, "AI_PROVIDER", "openai"
+        ), patch("ai.client.logger"):
+            mock_openai.side_effect = Exception("API初期化エラー")
+
+            with pytest.raises(RuntimeError):
+                get_client()
 
 
-def test_client_global_instance() -> None:
-    """グローバルなクライアントインスタンスが存在することをテスト"""
-    # 直接クライアントの存在を検証する方法に変更
-    from ai.client import client
+class TestVertexAIProvider:
+    """AI_PROVIDER=vertex_ai のテスト"""
 
-    # clientオブジェクトが存在するかチェック
-    assert client is not None
+    def test_get_client_creates_vertex_ai_client(self) -> None:
+        """Vertex AIクライアントが正しく作成されることをテスト"""
+        mock_creds = MagicMock()
+        mock_creds.valid = True
+        mock_creds.token = "test-access-token"
 
-    # OpenAIのインスタンスであるか
-    with patch("ai.client.OpenAI") as mock_openai:
-        # create_client関数をモックして検証
-        mock_client = MagicMock()
-        mock_openai.return_value = mock_client
+        with patch("ai.client.OpenAI") as mock_openai, patch.object(
+            config, "AI_PROVIDER", "vertex_ai"
+        ), patch.object(config, "VERTEX_AI_PROJECT_ID", "my-project"), patch.object(
+            config, "VERTEX_AI_LOCATION", "asia-northeast1"
+        ), patch(
+            "google.auth.default", return_value=(mock_creds, "my-project")
+        ):
+            mock_client = MagicMock()
+            mock_openai.return_value = mock_client
 
-        # 既存のクライアントが存在するか
-        from ai.client import client as existing_client
+            client = get_client()
 
-        assert existing_client is not None
+            mock_openai.assert_called_once_with(
+                api_key="test-access-token",
+                base_url=(
+                    "https://asia-northeast1-aiplatform.googleapis.com/v1beta1"
+                    "/projects/my-project/locations/asia-northeast1/endpoints/openapi"
+                ),
+            )
+            assert client == mock_client
+
+    def test_get_client_refreshes_expired_token(self) -> None:
+        """トークン期限切れ時にリフレッシュされることをテスト"""
+        mock_creds = MagicMock()
+        mock_creds.valid = False
+        mock_creds.token = "refreshed-token"
+
+        mock_request_class = MagicMock()
+
+        with patch("ai.client.OpenAI") as mock_openai, patch.object(
+            config, "AI_PROVIDER", "vertex_ai"
+        ), patch.object(config, "VERTEX_AI_PROJECT_ID", "my-project"), patch.object(
+            config, "VERTEX_AI_LOCATION", "asia-northeast1"
+        ), patch(
+            "google.auth.default", return_value=(mock_creds, "my-project")
+        ), patch(
+            "google.auth.transport.requests.Request",
+            return_value=mock_request_class,
+        ):
+            mock_openai.return_value = MagicMock()
+
+            get_client()
+
+            mock_creds.refresh.assert_called_once_with(mock_request_class)
+
+    def test_get_client_auto_detects_project_id(self) -> None:
+        """VERTEX_AI_PROJECT_IDが未設定の場合にgoogle.authから自動取得するテスト"""
+        mock_creds = MagicMock()
+        mock_creds.valid = True
+        mock_creds.token = "test-token"
+
+        with patch("ai.client.OpenAI"), patch.object(
+            config, "AI_PROVIDER", "vertex_ai"
+        ), patch.object(config, "VERTEX_AI_PROJECT_ID", ""), patch.object(
+            config, "VERTEX_AI_LOCATION", "asia-northeast1"
+        ), patch(
+            "google.auth.default", return_value=(mock_creds, "auto-detected-project")
+        ):
+            get_client()
+
+            assert config.VERTEX_AI_PROJECT_ID == "auto-detected-project"
+
+    def test_get_client_updates_token_on_subsequent_calls(self) -> None:
+        """2回目以降の呼び出しでトークンのみ更新されることをテスト"""
+        mock_creds = MagicMock()
+        mock_creds.valid = True
+        mock_creds.token = "initial-token"
+
+        with patch("ai.client.OpenAI") as mock_openai, patch.object(
+            config, "AI_PROVIDER", "vertex_ai"
+        ), patch.object(config, "VERTEX_AI_PROJECT_ID", "my-project"), patch.object(
+            config, "VERTEX_AI_LOCATION", "asia-northeast1"
+        ), patch(
+            "google.auth.default", return_value=(mock_creds, "my-project")
+        ):
+            mock_client = MagicMock()
+            mock_openai.return_value = mock_client
+
+            # 1回目の呼び出し
+            get_client()
+            mock_openai.assert_called_once()
+
+            # 2回目の呼び出し（新しいトークン）
+            mock_creds.token = "updated-token"
+            client2 = get_client()
+
+            # OpenAIコンストラクタは1回だけ呼ばれる（シングルトン）
+            mock_openai.assert_called_once()
+            # api_keyが更新されている
+            assert client2.api_key == "updated-token"
 
 
-def test_create_client_with_api_error() -> None:
-    """APIクライアント作成時にエラーが発生した場合の動作テスト"""
-    with patch("ai.client.OpenAI") as mock_openai, patch(
-        "ai.client.logger"
-    ) as mock_logger:
-        # OpenAIのコンストラクタで例外を発生させる
-        mock_openai.side_effect = Exception("API初期化エラー")
+class TestResetClient:
+    """reset_client()のテスト"""
 
-        # 例外が適切にキャッチされ、ログが出力されることを検証
-        with pytest.raises(RuntimeError):
-            create_client()
+    def test_reset_clears_state(self) -> None:
+        """リセット後に新しいクライアントが作成されることをテスト"""
+        with patch("ai.client.OpenAI") as mock_openai, patch.object(
+            config, "AI_PROVIDER", "openai"
+        ):
+            mock_client1 = MagicMock()
+            mock_client2 = MagicMock()
+            mock_openai.side_effect = [mock_client1, mock_client2]
 
-        mock_logger.error.assert_called_once()
+            client1 = get_client()
+            reset_client()
+            client2 = get_client()
+
+            assert mock_openai.call_count == 2
+            assert client1 is not client2

--- a/tests/test_utils/test_text_utils.py
+++ b/tests/test_utils/test_text_utils.py
@@ -61,28 +61,30 @@ def test_truncate_text_none() -> None:
 
 
 @pytest.mark.asyncio
-@patch("utils.text_utils.aiclient")
-async def test_translate_to_english_success(mock_aiclient: MagicMock) -> None:
+@patch("utils.text_utils.get_client")
+async def test_translate_to_english_success(mock_get_client: MagicMock) -> None:
     """英語翻訳が成功するケース"""
     # aiクライアントのモック設定
     mock_completion = MagicMock()
     mock_completion.choices[0].message.content = "This is a translation test."
-    mock_aiclient.chat.completions.create.return_value = mock_completion
+    mock_get_client.return_value.chat.completions.create.return_value = mock_completion
 
     # 関数実行
     result = await translate_to_english("これは翻訳テストです")
 
     # アサーション
     assert result == "This is a translation test."
-    mock_aiclient.chat.completions.create.assert_called_once()
+    mock_get_client.return_value.chat.completions.create.assert_called_once()
 
 
 @pytest.mark.asyncio
-@patch("utils.text_utils.aiclient")
-async def test_translate_to_english_error(mock_aiclient: MagicMock) -> None:
+@patch("utils.text_utils.get_client")
+async def test_translate_to_english_error(mock_get_client: MagicMock) -> None:
     """英語翻訳中にエラーが発生するケース"""
     # aiクライアントのモック設定
-    mock_aiclient.chat.completions.create.side_effect = Exception("API error")
+    mock_get_client.return_value.chat.completions.create.side_effect = Exception(
+        "API error"
+    )
 
     # 関数実行
     result = await translate_to_english("エラーになるテキスト")
@@ -92,28 +94,30 @@ async def test_translate_to_english_error(mock_aiclient: MagicMock) -> None:
 
 
 @pytest.mark.asyncio
-@patch("utils.text_utils.aiclient")
-async def test_translate_to_japanese_success(mock_aiclient: MagicMock) -> None:
+@patch("utils.text_utils.get_client")
+async def test_translate_to_japanese_success(mock_get_client: MagicMock) -> None:
     """日本語翻訳が成功するケース"""
     # aiクライアントのモック設定
     mock_completion = MagicMock()
     mock_completion.choices[0].message.content = "これは翻訳されたテキストです。"
-    mock_aiclient.chat.completions.create.return_value = mock_completion
+    mock_get_client.return_value.chat.completions.create.return_value = mock_completion
 
     # 関数実行
     result = await translate_to_japanese("This is a test for translation.")
 
     # アサーション
     assert result == "これは翻訳されたテキストです。"
-    mock_aiclient.chat.completions.create.assert_called_once()
+    mock_get_client.return_value.chat.completions.create.assert_called_once()
 
 
 @pytest.mark.asyncio
-@patch("utils.text_utils.aiclient")
-async def test_translate_to_japanese_error(mock_aiclient: MagicMock) -> None:
+@patch("utils.text_utils.get_client")
+async def test_translate_to_japanese_error(mock_get_client: MagicMock) -> None:
     """日本語翻訳中にエラーが発生するケース"""
     # aiクライアントのモック設定
-    mock_aiclient.chat.completions.create.side_effect = Exception("API error")
+    mock_get_client.return_value.chat.completions.create.side_effect = Exception(
+        "API error"
+    )
 
     # 関数実行
     result = await translate_to_japanese("Error causing text")

--- a/utils/text_utils.py
+++ b/utils/text_utils.py
@@ -1,7 +1,7 @@
 import asyncio
 
 import config
-from ai.client import client as aiclient
+from ai.client import get_client
 from log_utils.logger import logger
 
 # 定数の定義
@@ -91,7 +91,7 @@ async def translate_text(text: str, target_language: str = "english") -> str | N
         logger.info(f"{config_data['log_prefix']}翻訳リクエスト: {truncate_text(text)}")
 
         def _sync_translate():
-            return aiclient.chat.completions.create(
+            return get_client().chat.completions.create(
                 model=config.OPENAI_MODEL,
                 messages=[
                     {"role": "system", "content": config_data["system_prompt"]},

--- a/uv.lock
+++ b/uv.lock
@@ -986,6 +986,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "discord-py" },
+    { name = "google-auth" },
     { name = "google-cloud-firestore" },
     { name = "httpx" },
     { name = "openai" },
@@ -1006,6 +1007,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "discord-py", specifier = ">=2.0.0" },
+    { name = "google-auth" },
     { name = "google-cloud-firestore" },
     { name = "httpx" },
     { name = "openai" },


### PR DESCRIPTION
## 概要

AIプロバイダーとしてVertex AI（Gemini）を選択可能にし、OpenAIとの切り替えを環境変数で行えるようにした。

## 変更内容

- `AI_PROVIDER` 環境変数によるOpenAI / Vertex AIの切り替え機能を追加
- Vertex AI OpenAI互換APIクライアントの実装（GCE Workload Identity認証、トークン自動リフレッシュ）
- AIクライアントをモジュールレベル初期化から遅延初期化（`get_client()`）に変更
- `google-auth` を依存パッケージに追加
- README.md をVertex AI対応に更新
- PRテンプレートを整備

## 影響範囲

- [x] AI (client / conversation / tools)
- [ ] Bot (commands / events / discord_bot)
- [ ] XIVAPI
- [x] Utils (text_utils / channel_config / firestore)
- [x] Config / 環境変数
- [x] 依存パッケージ (pyproject.toml)
- [ ] Docker / CI

## テスト

- [x] `uv run python -m pytest` 全件パス
- [x] `uv run mypy .` 型チェックパス
- [x] カバレッジ 86% 以上を維持

## 補足

Vertex AIを利用する場合の設定例:
```env
AI_PROVIDER=vertex_ai
VERTEX_AI_LOCATION=asia-northeast1
OPENAI_MODEL=google/gemini-2.5-flash
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)