### PR TITLE
fix: 画像取得のセキュリティ強化とバグ修正

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,15 +1,14 @@
 DISCORD_TOKEN=
 BOT_NAME=スフェーン
 COMMAND_GROUP_NAME=sphene
-GEMINI_MODEL=gpt-4o-mini
 
 # AIプロバイダー設定: openai または vertex_ai
 AI_PROVIDER=vertex_ai
 
 # Vertex AI設定（AI_PROVIDER=vertex_ai の場合に使用）
 # VERTEX_AI_PROJECT_ID=your-gcp-project-id  # 未設定の場合はGCEメタデータから自動取得
-# VERTEX_AI_LOCATION=asia-northeast1
-# GEMINI_MODEL=google/gemini-2.5-flash
+VERTEX_AI_LOCATION=asia-northeast1
+GEMINI_MODEL=google/gemini-2.5-flash
 
 # システムプロンプトの設定
 SYSTEM_PROMPT_FILENAME=system.txt

--- a/ai/client.py
+++ b/ai/client.py
@@ -23,18 +23,20 @@ def _get_genai_client() -> genai.Client:
     
     # 認証情報を取得
     credentials, project = google.auth.default()
-    if not config.VERTEX_AI_PROJECT_ID:
-        config.VERTEX_AI_PROJECT_ID = project or ""
+    project_id = config.VERTEX_AI_PROJECT_ID or (project or "")
 
     # 新しいSDKのクライアント作成
     # vertexai=True を指定することで Vertex AI エンドポイントを使用する
     _client = genai.Client(
         vertexai=True,
-        project=config.VERTEX_AI_PROJECT_ID,
+        project=project_id,
         location=config.VERTEX_AI_LOCATION,
     )
     
-    logger.info(f"Google Gen AIクライアントを初期化しました（プロジェクト: {config.VERTEX_AI_PROJECT_ID}, リージョン: {config.VERTEX_AI_LOCATION}）")
+    logger.info(
+        "Google Gen AIクライアントを初期化しました（プロジェクト: "
+        f"{project_id}, リージョン: {config.VERTEX_AI_LOCATION}）"
+    )
     return _client
 
 

--- a/bot/events.py
+++ b/bot/events.py
@@ -32,7 +32,7 @@ async def is_bot_mentioned(
         Tuple[bool, str, bool]: (ボットに対するメッセージかどうか, 質問内容, リプライかどうか)
     """
     if message.content is None:
-        return False, ""
+        return False, "", False
 
     content: str = message.content
     user_id = str(message.author.id)
@@ -609,7 +609,7 @@ async def _handle_reaction(
         # エラーが発生した場合、可能であればチャンネルにメッセージを送信
         try:
             await reaction.message.channel.send(
-                f"リアクション処理中にエラーが発生しました 😢: {str(e)}"
+                "リアクション処理中にエラーが発生しました 😢"
             )
         except Exception:
             pass

--- a/tests/test_ai/test_conversation_genai.py
+++ b/tests/test_ai/test_conversation_genai.py
@@ -1,0 +1,157 @@
+"""ai/conversation.py のgoogle-genai向けテスト"""
+
+from unittest.mock import MagicMock, patch
+
+from google.genai import types
+
+from ai.conversation import MAX_IMAGE_BYTES, Sphene
+
+DISCORD_CDN_URL = "https://cdn.discordapp.com/attachments/123/456/img.jpg"
+DISCORD_MEDIA_URL = "https://media.discordapp.net/attachments/123/456/img.jpg"
+
+
+def _make_response_mock(**kwargs):
+    """stream=True + with文対応のレスポンスモックを生成"""
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.headers = kwargs.get("headers", {})
+    resp.iter_content.return_value = kwargs.get("chunks", [])
+    resp.__enter__ = MagicMock(return_value=resp)
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+def test_input_message_skips_oversize_image() -> None:
+    """サイズ超過の画像はスキップされることを確認"""
+    sphene = Sphene(system_setting="System")
+
+    with patch("ai.conversation._call_genai_with_tools") as mock_call, patch(
+        "requests.get"
+    ) as mock_get, patch("ai.conversation.types.Part.from_bytes") as mock_from_bytes:
+        mock_get.return_value = _make_response_mock(
+            headers={
+                "Content-Type": "image/jpeg",
+                "Content-Length": str(MAX_IMAGE_BYTES + 1),
+            },
+            chunks=[b"x" * 10],
+        )
+
+        mock_call.return_value = (True, "ok", [])
+
+        result = sphene.input_message("hi", [DISCORD_CDN_URL])
+
+        assert result == "ok"
+        mock_get.assert_called_once()
+        mock_from_bytes.assert_not_called()
+
+
+def test_input_message_skips_non_image_content_type() -> None:
+    """画像以外のContent-Typeはスキップされることを確認"""
+    sphene = Sphene(system_setting="System")
+
+    with patch("ai.conversation._call_genai_with_tools") as mock_call, patch(
+        "requests.get"
+    ) as mock_get, patch("ai.conversation.types.Part.from_bytes") as mock_from_bytes:
+        mock_get.return_value = _make_response_mock(
+            headers={"Content-Type": "text/plain"},
+            chunks=[b"not-an-image"],
+        )
+
+        mock_call.return_value = (True, "ok", [])
+
+        result = sphene.input_message("hi", [DISCORD_CDN_URL])
+
+        assert result == "ok"
+        mock_get.assert_called_once()
+        mock_from_bytes.assert_not_called()
+
+
+def test_input_message_skips_streaming_overflow_without_length() -> None:
+    """Content-Lengthが無くても上限超過ならスキップされることを確認"""
+    sphene = Sphene(system_setting="System")
+
+    with patch("ai.conversation._call_genai_with_tools") as mock_call, patch(
+        "requests.get"
+    ) as mock_get, patch("ai.conversation.types.Part.from_bytes") as mock_from_bytes:
+        big_chunk = b"x" * (MAX_IMAGE_BYTES + 1)
+        mock_get.return_value = _make_response_mock(
+            headers={"Content-Type": "image/jpeg"},
+            chunks=[big_chunk],
+        )
+
+        mock_call.return_value = (True, "ok", [])
+
+        result = sphene.input_message("hi", [DISCORD_CDN_URL])
+
+        assert result == "ok"
+        mock_get.assert_called_once()
+        mock_from_bytes.assert_not_called()
+
+
+def test_input_message_skips_disallowed_domain() -> None:
+    """許可されていないドメインの画像URLはフェッチされないことを確認"""
+    sphene = Sphene(system_setting="System")
+
+    with patch("ai.conversation._call_genai_with_tools") as mock_call, patch(
+        "requests.get"
+    ) as mock_get, patch("ai.conversation.types.Part.from_bytes") as mock_from_bytes:
+        mock_call.return_value = (True, "ok", [])
+
+        result = sphene.input_message("hi", ["https://evil.example.com/img.jpg"])
+
+        assert result == "ok"
+        mock_get.assert_not_called()
+        mock_from_bytes.assert_not_called()
+
+
+def test_input_message_allows_discord_media_domain() -> None:
+    """media.discordapp.netドメインの画像は取得されることを確認"""
+    sphene = Sphene(system_setting="System")
+
+    fake_part = types.Part.from_bytes(data=b"fake", mime_type="image/png")
+
+    with patch("ai.conversation._call_genai_with_tools") as mock_call, patch(
+        "requests.get"
+    ) as mock_get, patch(
+        "ai.conversation.types.Part.from_bytes", return_value=fake_part
+    ) as mock_from_bytes:
+        mock_get.return_value = _make_response_mock(
+            headers={"Content-Type": "image/png"},
+            chunks=[b"fake-image-data"],
+        )
+
+        mock_call.return_value = (True, "ok", [])
+
+        result = sphene.input_message("hi", [DISCORD_MEDIA_URL])
+
+        assert result == "ok"
+        mock_get.assert_called_once()
+        mock_from_bytes.assert_called_once()
+
+
+def test_input_message_handles_invalid_content_length() -> None:
+    """不正なContent-Lengthヘッダーでもクラッシュしないことを確認"""
+    sphene = Sphene(system_setting="System")
+
+    fake_part = types.Part.from_bytes(data=b"fake", mime_type="image/jpeg")
+
+    with patch("ai.conversation._call_genai_with_tools") as mock_call, patch(
+        "requests.get"
+    ) as mock_get, patch(
+        "ai.conversation.types.Part.from_bytes", return_value=fake_part
+    ) as mock_from_bytes:
+        mock_get.return_value = _make_response_mock(
+            headers={
+                "Content-Type": "image/jpeg",
+                "Content-Length": "invalid",
+            },
+            chunks=[b"small-image"],
+        )
+
+        mock_call.return_value = (True, "ok", [])
+
+        result = sphene.input_message("hi", [DISCORD_CDN_URL])
+
+        assert result == "ok"
+        # Content-Lengthが不正でもクラッシュせず、ストリーミングで読み込まれる
+        mock_from_bytes.assert_called_once()

--- a/tests/test_bot/test_events_extensive.py
+++ b/tests/test_bot/test_events_extensive.py
@@ -64,6 +64,20 @@ class TestEventsExtensive:
         assert is_reply is True
 
     @pytest.mark.asyncio
+    async def test_is_bot_mentioned_no_content(self):
+        """message.contentがNoneでも例外なく3要素を返すことを確認"""
+        bot = MagicMock()
+        msg = MagicMock()
+        msg.content = None
+        msg.mentions = []
+        msg.reference = None
+
+        mentioned, q, is_reply = await is_bot_mentioned(bot, msg)
+        assert mentioned is False
+        assert q == ""
+        assert is_reply is False
+
+    @pytest.mark.asyncio
     @patch("bot.events.user_conversations")
     @patch("bot.events.split_message")
     async def test_process_conversation_chunking(self, mock_split, mock_conversations):

--- a/utils/channel_config.py
+++ b/utils/channel_config.py
@@ -412,7 +412,7 @@ class ChannelConfig:
         result = False
 
         # 詳細なログ記録
-        logger.info(
+        logger.debug(
             f"can_bot_speak: ギルドID={self.guild_id}, チャンネルID={channel_id}, "
             f"behavior={behavior}, in_list={in_list}, "
             f"チャンネル数={len(self.get_channels())}"
@@ -425,18 +425,18 @@ class ChannelConfig:
                 for c in self.get_channels()
             ]
         )
-        logger.info(f"チャンネルリスト内のID: [{channels_str}]")
+        logger.debug(f"チャンネルリスト内のID: [{channels_str}]")
 
         # 限定モード: リストにあるチャンネルのみ許可
         if behavior == "allow":
             result = in_list
-            logger.info(
+            logger.debug(
                 f"限定モード判定: {result} (リストに{'' if in_list else '不'}一致)"
             )
         # 全体モード: リストにないチャンネルのみ許可
         else:
             result = not in_list
-            logger.info(
+            logger.debug(
                 f"全体モード判定: {result} (リストに{'' if in_list else '不'}一致)"
             )
 


### PR DESCRIPTION
<!--
GitHub Copilot コードレビューへの指示： このリポジトリのプルリクエストをレビューしてコメントする場合には日本語で記載してください。
-->

## 概要

コードレビューで発見された画像取得処理のセキュリティリスク・バグ・保守性の問題を修正。

## 変更内容

- **[SECURITY] SSRF防御**: `ALLOWED_IMAGE_DOMAINS`（`cdn.discordapp.com`, `media.discordapp.net`）で画像取得先を制限し、内部ネットワークへのアクセスを防止
- **[BUG] stream=Trueリソースリーク修正**: `requests.get(stream=True)` を `with` 文で囲み、コネクションを確実にクローズ
- **[BUG] Content-Length不正値ガード**: `int(content_length)` を `try/except (ValueError, TypeError)` でラップ
- **[BUG] `is_bot_mentioned`戻り値修正**: `content=None` 時に2要素タプルを返していたのを3要素に修正
- **[SECURITY] エラーメッセージの内部情報漏洩除去**: リアクション処理エラーで `str(e)` をユーザーに見せないように変更
- **[MAINTENANCE] ログレベル適正化**: `can_bot_speak` のログを `info` → `debug` に変更
- **[MAINTENANCE] config副作用除去**: `_get_genai_client` でグローバル状態への書き込みをローカル変数に変更
- **[CLEANUP] dead codeフォールバック削除**: `mime_type` の到達不可能な `or "image/jpeg"` を削除

## 影響範囲

- [x] AI (client / conversation / tools)
- [x] Bot (commands / events / discord_bot)
- [ ] XIVAPI
- [x] Utils (text_utils / channel_config / firestore)
- [x] Config / 環境変数
- [ ] 依存パッケージ (pyproject.toml)
- [ ] Docker / CI

## テスト

- [x] `uv run python -m pytest` 関連テスト全件パス（既存のSDK移行由来の失敗は変更前から存在）
- [ ] `uv run mypy .` 型チェックパス
- [ ] カバレッジ 86% 以上を維持

### 追加テスト
- `test_input_message_skips_disallowed_domain` — 許可外ドメインのブロック検証
- `test_input_message_allows_discord_media_domain` — 正規ドメインの許可検証
- `test_input_message_handles_invalid_content_length` — 不正Content-Lengthのハンドリング検証
- `test_is_bot_mentioned_no_content` — content=None時の3要素タプル返却検証

## 補足

既存テストの41件の失敗は、前回のSDK移行(#51)で `get_client` が削除された影響で、本PRの変更とは無関係です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)