### PR TITLE
fix: Google Gen AI SDK移行に伴うテストの修正

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,13 +47,19 @@ def mock_discord_interaction() -> MagicMock:
 
 
 @pytest.fixture()
-def mock_openai_response() -> MagicMock:
-    """OpenAI APIレスポンスのモック"""
+def mock_genai_response() -> MagicMock:
+    """Google Gen AI APIレスポンスのモック"""
+    mock_part = MagicMock()
+    mock_part.text = "これはテスト応答です。"
+    mock_part.function_call = None
+
+    mock_content = MagicMock()
+    mock_content.parts = [mock_part]
+    mock_content.role = "model"
+
     mock_response = MagicMock()
-    mock_choice = MagicMock()
-    mock_choice.message.content = "これはテスト応答です。"
-    mock_choice.message.tool_calls = None
-    mock_response.choices = [mock_choice]
+    mock_response.candidates = [MagicMock(content=mock_content)]
+    mock_response.text = "これはテスト応答です。"
     return mock_response
 
 

--- a/tests/test_ai/test_client.py
+++ b/tests/test_ai/test_client.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import config
-from ai.client import get_client, reset_client
+from ai.client import _get_genai_client, get_model_name, reset_client
 
 
 @pytest.fixture(autouse=True)
@@ -14,158 +14,83 @@ def _reset_client_state() -> None:
     reset_client()
 
 
-class TestOpenAIProvider:
-    """AI_PROVIDER=openai のテスト"""
+class TestGetGenaiClient:
+    """_get_genai_client()のテスト"""
 
-    def test_get_client_creates_openai_client(
-        self, mock_env_vars: dict[str, str]
-    ) -> None:
-        """OpenAIクライアントが正しく作成されることをテスト"""
-        with patch("ai.client.OpenAI") as mock_openai, patch.object(
-            config, "AI_PROVIDER", "openai"
-        ):
-            mock_client = MagicMock()
-            mock_openai.return_value = mock_client
-
-            client = get_client()
-
-            mock_openai.assert_called_once_with(api_key=config.OPENAI_API_KEY)
-            assert client == mock_client
-
-    def test_get_client_returns_singleton(
-        self, mock_env_vars: dict[str, str]
-    ) -> None:
-        """同じインスタンスが返されることをテスト（シングルトン）"""
-        with patch("ai.client.OpenAI") as mock_openai, patch.object(
-            config, "AI_PROVIDER", "openai"
-        ):
-            mock_client = MagicMock()
-            mock_openai.return_value = mock_client
-
-            client1 = get_client()
-            client2 = get_client()
-
-            mock_openai.assert_called_once()
-            assert client1 is client2
-
-    def test_get_client_with_empty_api_key(self) -> None:
-        """APIキーが空でもクライアントが作成されることをテスト"""
-        with patch("ai.client.OpenAI") as mock_openai, patch.object(
-            config, "AI_PROVIDER", "openai"
-        ), patch.object(config, "OPENAI_API_KEY", ""):
-            get_client()
-            mock_openai.assert_called_once_with(api_key="")
-
-    def test_get_client_with_api_error(self) -> None:
-        """クライアント作成時にエラーが発生した場合のテスト"""
-        with patch("ai.client.OpenAI") as mock_openai, patch.object(
-            config, "AI_PROVIDER", "openai"
-        ), patch("ai.client.logger"):
-            mock_openai.side_effect = Exception("API初期化エラー")
-
-            with pytest.raises(RuntimeError):
-                get_client()
-
-
-class TestVertexAIProvider:
-    """AI_PROVIDER=vertex_ai のテスト"""
-
-    def test_get_client_creates_vertex_ai_client(self) -> None:
-        """Vertex AIクライアントが正しく作成されることをテスト"""
+    def test_creates_genai_client(self) -> None:
+        """Google Gen AIクライアントが正しく作成されることをテスト"""
         mock_creds = MagicMock()
-        mock_creds.valid = True
-        mock_creds.token = "test-access-token"
 
-        with patch("ai.client.OpenAI") as mock_openai, patch.object(
-            config, "AI_PROVIDER", "vertex_ai"
+        with patch("ai.client.genai.Client") as mock_client_cls, patch(
+            "ai.client.google.auth.default",
+            return_value=(mock_creds, "my-project"),
         ), patch.object(config, "VERTEX_AI_PROJECT_ID", "my-project"), patch.object(
             config, "VERTEX_AI_LOCATION", "asia-northeast1"
-        ), patch(
-            "google.auth.default", return_value=(mock_creds, "my-project")
         ):
             mock_client = MagicMock()
-            mock_openai.return_value = mock_client
+            mock_client_cls.return_value = mock_client
 
-            client = get_client()
+            client = _get_genai_client()
 
-            mock_openai.assert_called_once_with(
-                api_key="test-access-token",
-                base_url=(
-                    "https://asia-northeast1-aiplatform.googleapis.com/v1beta1"
-                    "/projects/my-project/locations/asia-northeast1/endpoints/openapi"
-                ),
+            mock_client_cls.assert_called_once_with(
+                vertexai=True,
+                project="my-project",
+                location="asia-northeast1",
             )
             assert client == mock_client
 
-    def test_get_client_refreshes_expired_token(self) -> None:
-        """トークン期限切れ時にリフレッシュされることをテスト"""
+    def test_returns_singleton(self) -> None:
+        """同じインスタンスが返されることをテスト（シングルトン）"""
         mock_creds = MagicMock()
-        mock_creds.valid = False
-        mock_creds.token = "refreshed-token"
 
-        mock_request_class = MagicMock()
-
-        with patch("ai.client.OpenAI") as mock_openai, patch.object(
-            config, "AI_PROVIDER", "vertex_ai"
+        with patch("ai.client.genai.Client") as mock_client_cls, patch(
+            "ai.client.google.auth.default",
+            return_value=(mock_creds, "my-project"),
         ), patch.object(config, "VERTEX_AI_PROJECT_ID", "my-project"), patch.object(
             config, "VERTEX_AI_LOCATION", "asia-northeast1"
-        ), patch(
-            "google.auth.default", return_value=(mock_creds, "my-project")
-        ), patch(
-            "google.auth.transport.requests.Request",
-            return_value=mock_request_class,
-        ):
-            mock_openai.return_value = MagicMock()
-
-            get_client()
-
-            mock_creds.refresh.assert_called_once_with(mock_request_class)
-
-    def test_get_client_auto_detects_project_id(self) -> None:
-        """VERTEX_AI_PROJECT_IDが未設定の場合にgoogle.authから自動取得するテスト"""
-        mock_creds = MagicMock()
-        mock_creds.valid = True
-        mock_creds.token = "test-token"
-
-        with patch("ai.client.OpenAI"), patch.object(
-            config, "AI_PROVIDER", "vertex_ai"
-        ), patch.object(config, "VERTEX_AI_PROJECT_ID", ""), patch.object(
-            config, "VERTEX_AI_LOCATION", "asia-northeast1"
-        ), patch(
-            "google.auth.default", return_value=(mock_creds, "auto-detected-project")
-        ):
-            get_client()
-
-            assert config.VERTEX_AI_PROJECT_ID == "auto-detected-project"
-
-    def test_get_client_updates_token_on_subsequent_calls(self) -> None:
-        """2回目以降の呼び出しでトークンのみ更新されることをテスト"""
-        mock_creds = MagicMock()
-        mock_creds.valid = True
-        mock_creds.token = "initial-token"
-
-        with patch("ai.client.OpenAI") as mock_openai, patch.object(
-            config, "AI_PROVIDER", "vertex_ai"
-        ), patch.object(config, "VERTEX_AI_PROJECT_ID", "my-project"), patch.object(
-            config, "VERTEX_AI_LOCATION", "asia-northeast1"
-        ), patch(
-            "google.auth.default", return_value=(mock_creds, "my-project")
         ):
             mock_client = MagicMock()
-            mock_openai.return_value = mock_client
+            mock_client_cls.return_value = mock_client
 
-            # 1回目の呼び出し
-            get_client()
-            mock_openai.assert_called_once()
+            client1 = _get_genai_client()
+            client2 = _get_genai_client()
 
-            # 2回目の呼び出し（新しいトークン）
-            mock_creds.token = "updated-token"
-            client2 = get_client()
+            mock_client_cls.assert_called_once()
+            assert client1 is client2
 
-            # OpenAIコンストラクタは1回だけ呼ばれる（シングルトン）
-            mock_openai.assert_called_once()
-            # api_keyが更新されている
-            assert client2.api_key == "updated-token"
+    def test_auto_detects_project_id(self) -> None:
+        """VERTEX_AI_PROJECT_IDが未設定の場合にgoogle.authから自動取得するテスト"""
+        mock_creds = MagicMock()
+
+        with patch("ai.client.genai.Client") as mock_client_cls, patch(
+            "ai.client.google.auth.default",
+            return_value=(mock_creds, "auto-detected-project"),
+        ), patch.object(config, "VERTEX_AI_PROJECT_ID", ""), patch.object(
+            config, "VERTEX_AI_LOCATION", "asia-northeast1"
+        ):
+            mock_client_cls.return_value = MagicMock()
+
+            _get_genai_client()
+
+            mock_client_cls.assert_called_once_with(
+                vertexai=True,
+                project="auto-detected-project",
+                location="asia-northeast1",
+            )
+
+
+class TestGetModelName:
+    """get_model_name()のテスト"""
+
+    def test_strips_google_prefix(self) -> None:
+        """google/ プレフィックスが除去されることをテスト"""
+        with patch.object(config, "GEMINI_MODEL", "google/gemini-2.5-flash"):
+            assert get_model_name() == "gemini-2.5-flash"
+
+    def test_keeps_name_without_prefix(self) -> None:
+        """プレフィックスなしのモデル名がそのまま返されることをテスト"""
+        with patch.object(config, "GEMINI_MODEL", "gemini-2.5-pro"):
+            assert get_model_name() == "gemini-2.5-pro"
 
 
 class TestResetClient:
@@ -173,16 +98,21 @@ class TestResetClient:
 
     def test_reset_clears_state(self) -> None:
         """リセット後に新しいクライアントが作成されることをテスト"""
-        with patch("ai.client.OpenAI") as mock_openai, patch.object(
-            config, "AI_PROVIDER", "openai"
+        mock_creds = MagicMock()
+
+        with patch("ai.client.genai.Client") as mock_client_cls, patch(
+            "ai.client.google.auth.default",
+            return_value=(mock_creds, "my-project"),
+        ), patch.object(config, "VERTEX_AI_PROJECT_ID", "my-project"), patch.object(
+            config, "VERTEX_AI_LOCATION", "asia-northeast1"
         ):
             mock_client1 = MagicMock()
             mock_client2 = MagicMock()
-            mock_openai.side_effect = [mock_client1, mock_client2]
+            mock_client_cls.side_effect = [mock_client1, mock_client2]
 
-            client1 = get_client()
+            client1 = _get_genai_client()
             reset_client()
-            client2 = get_client()
+            client2 = _get_genai_client()
 
-            assert mock_openai.call_count == 2
+            assert mock_client_cls.call_count == 2
             assert client1 is not client2

--- a/tests/test_ai/test_conversation_extensive.py
+++ b/tests/test_ai/test_conversation_extensive.py
@@ -5,23 +5,17 @@ ai/conversation.py の広範なテスト
 # type: ignore
 # mypy: ignore-errors
 
-import json
-import logging
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
-from openai import (
-    APIConnectionError,
-    APIError,
-    APIStatusError,
-    APITimeoutError,
-    AuthenticationError,
-    RateLimitError,
-)
+from google.genai import types
 
 from ai.conversation import (
     Sphene,
+    _call_genai_with_tools,
+    _execute_tool_calls,
+    _handle_api_error,
     cleanup_expired_conversations,
     generate_contextual_response,
     load_system_prompt,
@@ -43,17 +37,17 @@ class TestConversationExtensive:
     def test_load_system_prompt_cache(self, mock_load_local):
         """システムプロンプトのキャッシュ動作テスト"""
         mock_load_local.return_value = "Custom Prompt"
-        
+
         # 1回目：ロードされる
         p1 = load_system_prompt()
         assert p1 == "Custom Prompt"
         assert mock_load_local.call_count == 1
-        
+
         # 2回目：キャッシュから返される
         p2 = load_system_prompt()
         assert p2 == "Custom Prompt"
         assert mock_load_local.call_count == 1
-        
+
         # 強制リロード
         p3 = load_system_prompt(force_reload=True)
         assert p3 == "Custom Prompt"
@@ -70,13 +64,12 @@ class TestConversationExtensive:
     @patch("ai.conversation.load_system_prompt")
     def test_reload_system_prompt_failure(self, mock_load_prompt):
         """プロンプト再読み込み失敗テスト"""
-        # load_system_prompt が例外を投げた場合、reload_system_prompt は False を返すか再スローする
         mock_load_prompt.side_effect = Exception("Load Error")
-        
+
         # fail_on_error=False
         result = reload_system_prompt(fail_on_error=False)
         assert result is False
-        
+
         # fail_on_error=True
         with pytest.raises(Exception):
             reload_system_prompt(fail_on_error=True)
@@ -84,158 +77,189 @@ class TestConversationExtensive:
     def test_trim_conversation_history_safety(self):
         """トリミング時の安全な切断ポイントのテスト"""
         sphene = Sphene("System")
-        
-        # 往復上限を超えるメッセージを追加
-        # role: user で始まるように調整
-        sphene.input_list = [{"role": "system", "content": "System"}]
-        for i in range(15):
-            sphene.input_list.append({"role": "user", "content": f"User {i}"})
-            sphene.input_list.append({"role": "assistant", "content": f"Asst {i}"})
-        
-        sphene.trim_conversation_history()
-        
-        # システムメッセージ(1) + 往復10回(20) = 21メッセージ
-        assert len(sphene.input_list) == 21
-        assert sphene.input_list[0]["role"] == "system"
-        # 最初が assistant か user かを確認（trimのロジックでは user または tool_callsなしassistantを探す）
-        assert sphene.input_list[1]["role"] in ["user", "assistant"]
 
-    def test_handle_openai_error_mapping(self):
-        """OpenAIエラーハンドリングのマッピングテスト"""
-        sphene = Sphene("System")
-        
-        # 各エラータイプに対するユーザーメッセージを確認
+        # 往復上限を超えるメッセージを追加
+        for i in range(30):
+            content = MagicMock()
+            content.role = "user" if i % 2 == 0 else "model"
+            sphene.history.append(content)
+
+        sphene.trim_conversation_history()
+
+        # MAX_CONVERSATION_TURNS * 2 以下であること
+        assert len(sphene.history) <= 20
+        # 先頭がuserメッセージであること
+        assert sphene.history[0].role == "user"
+
+    def test_handle_api_error_mapping(self):
+        """APIエラーハンドリングのマッピングテスト"""
         errors = [
-            (AuthenticationError("auth", response=MagicMock(), body={}), "接続設定で問題"),
-            (RateLimitError("rate", response=MagicMock(), body={}), "混み合ってる"),
-            (APIConnectionError(request=MagicMock()), "接続で問題"),
-            (APITimeoutError(request=MagicMock()), "時間内"), # "タイムアウト" は含まれていない
-            (APIStatusError("status", response=MagicMock(status_code=502), body={}), "通信で予期せぬエラー"),
-            (Exception("General Error"), "通信中に予期せぬエラー"),
+            (Exception("404 Not Found"), "指定されたAIモデル"),
+            (Exception("429 Too Many Requests"), "混み合ってる"),
+            (Exception("General Error"), "通信中にエラー"),
         ]
-        
+
         for err, expected_part in errors:
-            msg = sphene._handle_openai_error(err)
+            msg = _handle_api_error(err)
             assert expected_part in msg
 
     @patch("ai.conversation.TOOL_FUNCTIONS")
     def test_execute_tool_calls_success(self, mock_tools):
         """ツール呼び出し実行の成功テスト"""
-        mock_func = MagicMock(return_value="Tool Result")
+        mock_func = MagicMock(return_value={"result": "success"})
         mock_tools.get.return_value = mock_func
-        
-        sphene = Sphene("System")
-        
-        mock_tool_call = MagicMock()
-        mock_tool_call.function.name = "test_tool"
-        mock_tool_call.function.arguments = '{"arg": "val"}'
-        mock_tool_call.id = "call_123"
-        
-        results = sphene._execute_tool_calls([mock_tool_call])
-        
+
+        mock_call = MagicMock()
+        mock_call.name = "test_tool"
+        mock_call.args = {"arg": "val"}
+
+        results = _execute_tool_calls([mock_call])
+
         assert len(results) == 1
-        assert results[0]["role"] == "tool"
-        assert results[0]["content"] == "Tool Result"
-        assert results[0]["tool_call_id"] == "call_123"
         mock_func.assert_called_once_with(arg="val")
 
     @patch("ai.conversation.TOOL_FUNCTIONS")
-    def test_execute_tool_calls_json_error(self, mock_tools):
-        """ツール引数のJSONエラーテスト"""
-        mock_tools.get.return_value = MagicMock()
-        sphene = Sphene("System")
-        
-        mock_tool_call = MagicMock()
-        mock_tool_call.function.name = "test_tool"
-        mock_tool_call.function.arguments = "invalid json"
-        mock_tool_call.id = "call_err"
-        
-        results = sphene._execute_tool_calls([mock_tool_call])
-        assert "パースに失敗" in results[0]["content"]
+    def test_execute_tool_calls_unknown_function(self, mock_tools):
+        """未知のツール関数の呼び出しテスト"""
+        mock_tools.get.return_value = None
 
-    @patch("ai.conversation.get_client")
-    def test_call_with_tool_loop_max_rounds(self, mock_get_client):
+        mock_call = MagicMock()
+        mock_call.name = "unknown_tool"
+        mock_call.args = {}
+
+        results = _execute_tool_calls([mock_call])
+
+        assert len(results) == 1
+        # エラーは発生せず、結果が返される
+
+    @patch("ai.conversation.TOOL_FUNCTIONS")
+    def test_execute_tool_calls_function_error(self, mock_tools):
+        """ツール関数がエラーを投げた場合のテスト"""
+        mock_func = MagicMock(side_effect=Exception("ツール内部エラー"))
+        mock_tools.get.return_value = mock_func
+
+        mock_call = MagicMock()
+        mock_call.name = "error_tool"
+        mock_call.args = {"key": "value"}
+
+        results = _execute_tool_calls([mock_call])
+
+        assert len(results) == 1
+        # エラーは捕捉されて結果が返される
+
+    @patch("ai.conversation.get_model_name")
+    @patch("ai.conversation._get_genai_client")
+    def test_call_genai_with_tools_max_rounds(
+        self, mock_get_client, mock_model_name
+    ):
         """ツール呼び出しの無限ループ防止テスト"""
-        # 常にツール呼び出しを返すモック
-        mock_msg = MagicMock()
-        mock_tool_call = MagicMock()
-        mock_tool_call.function.name = "loop_tool"
-        mock_tool_call.function.arguments = "{}"
-        mock_msg.tool_calls = [mock_tool_call]
-        
+        mock_model_name.return_value = "gemini-2.5-flash"
+
+        # 常にfunction_callを返すレスポンスを作成
+        mock_fc = MagicMock()
+        mock_fc.name = "loop_tool"
+        mock_fc.args = {}
+
+        mock_part = MagicMock()
+        mock_part.function_call = mock_fc
+        mock_part.text = None
+
+        mock_content = MagicMock()
+        mock_content.parts = [mock_part]
+
         mock_response = MagicMock()
-        mock_response.choices = [MagicMock(message=mock_msg)]
-        mock_get_client().chat.completions.create.return_value = mock_response
-        
-        sphene = Sphene("System")
-        # 内部で実行される _execute_tool_calls をモック
-        sphene._execute_tool_calls = MagicMock(return_value=[{"role": "tool", "content": "res", "tool_call_id": "id"}])
-        
-        success, msg = sphene._call_with_tool_loop()
+        mock_response.candidates = [MagicMock(content=mock_content)]
+        mock_get_client.return_value.models.generate_content.return_value = (
+            mock_response
+        )
+
+        # 実際のtypes.Partオブジェクトを使う（pydanticバリデーション対策）
+        fn_response_part = types.Part.from_function_response(
+            name="loop_tool", response={"result": "ok"}
+        )
+        with patch(
+            "ai.conversation._execute_tool_calls",
+            return_value=[fn_response_part],
+        ):
+            success, msg, _ = _call_genai_with_tools([], "system")
+
         assert success is False
         assert "複雑すぎて" in msg
-        # MAX_TOOL_CALL_ROUNDS (3) + 1 = 4 回呼ばれるはず
-        assert mock_get_client().chat.completions.create.call_count == 4
 
-    @patch("ai.conversation.load_system_prompt")
-    @patch("ai.conversation.get_client")
-    def test_generate_contextual_response_success(self, mock_get_client, mock_load_prompt):
+    @patch("ai.conversation._call_genai_with_tools")
+    def test_generate_contextual_response_success(self, mock_call):
         """コンテキスト付き応答生成の成功テスト"""
-        mock_load_prompt.return_value = "System"
-        mock_get_client().chat.completions.create.return_value.choices[0].message.content = "Contextual Answer"
-        
+        mock_call.return_value = (True, "Contextual Answer", [])
+
         result = generate_contextual_response("Recent context", "Trigger")
         assert result == "Contextual Answer"
+
+    @patch("ai.conversation._call_genai_with_tools")
+    def test_generate_contextual_response_failure(self, mock_call):
+        """コンテキスト付き応答生成の失敗テスト"""
+        mock_call.return_value = (False, "エラー", [])
+
+        result = generate_contextual_response("Recent context", "Trigger")
+        assert result is None
 
     def test_cleanup_expired_conversations(self):
         """期限切れ会話のクリーンアップテスト"""
         # 有効な会話
         s1 = Sphene("S1")
         user_conversations["u1"] = s1
-        
+
         # 期限切れの会話
         s2 = Sphene("S2")
         s2.last_interaction = datetime.now() - timedelta(hours=1)
         user_conversations["u2"] = s2
-        
+
         count = cleanup_expired_conversations()
         assert count == 1
         assert "u1" in user_conversations
         assert "u2" not in user_conversations
 
-    @patch("requests.head")
-    @patch("requests.get")
-    def test_process_images_complete_failure(self, mock_get, mock_head):
-        """画像処理が完全に失敗する場合のテスト"""
-        mock_head.side_effect = Exception("Head Error")
-        mock_get.side_effect = Exception("Get Error")
-        
-        sphene = Sphene("System")
-        results = sphene._process_images(["https://bad.url/img.jpg"])
-        
-        # 失敗した場合は結果リストが空になる
-        assert len(results) == 0
+    @patch("ai.conversation.get_model_name")
+    @patch("ai.conversation._get_genai_client")
+    def test_call_genai_with_tools_text_response(
+        self, mock_get_client, mock_model_name
+    ):
+        """テキスト応答の正常処理テスト"""
+        mock_model_name.return_value = "gemini-2.5-flash"
 
-    def test_download_and_encode_image_extension_guessing(self):
-        """MIMEタイプ推測のテスト"""
-        sphene = Sphene("System")
-        
-        with patch("requests.get") as mock_get:
-            mock_get.return_value.content = b"data"
-            mock_get.return_value.headers = {}
-            
-            # .png
-            res1 = sphene._download_and_encode_image("https://t.com/i.png")
-            assert "image/png" in res1
-            
-            # .webp
-            res2 = sphene._download_and_encode_image("https://t.com/i.webp")
-            assert "image/webp" in res2
-            
-            # .gif
-            res3 = sphene._download_and_encode_image("https://t.com/i.gif")
-            assert "image/gif" in res3
-            
-            # 不明な拡張子はデフォルト image/jpeg
-            res4 = sphene._download_and_encode_image("https://t.com/i.unknown")
-            assert "image/jpeg" in res4
+        # テキスト応答のみを返すレスポンス
+        mock_part = MagicMock()
+        mock_part.function_call = None
+        mock_part.text = "Hello from GenAI"
+
+        mock_content = MagicMock()
+        mock_content.parts = [mock_part]
+
+        mock_response = MagicMock()
+        mock_response.candidates = [MagicMock(content=mock_content)]
+        mock_get_client.return_value.models.generate_content.return_value = (
+            mock_response
+        )
+
+        success, text, history = _call_genai_with_tools([], "system")
+
+        assert success is True
+        assert text == "Hello from GenAI"
+
+    @patch("ai.conversation.get_model_name")
+    @patch("ai.conversation._get_genai_client")
+    def test_call_genai_with_tools_empty_candidates(
+        self, mock_get_client, mock_model_name
+    ):
+        """空のcandidatesが返された場合のテスト"""
+        mock_model_name.return_value = "gemini-2.5-flash"
+
+        mock_response = MagicMock()
+        mock_response.candidates = []
+        mock_get_client.return_value.models.generate_content.return_value = (
+            mock_response
+        )
+
+        success, text, _ = _call_genai_with_tools([], "system")
+
+        assert success is False
+        assert "空" in text

--- a/tests/test_utils/test_text_utils.py
+++ b/tests/test_utils/test_text_utils.py
@@ -61,73 +61,81 @@ def test_truncate_text_none() -> None:
 
 
 @pytest.mark.asyncio
-@patch("utils.text_utils.get_client")
-async def test_translate_to_english_success(mock_get_client: MagicMock) -> None:
+@patch("utils.text_utils.get_model_name")
+@patch("utils.text_utils._get_genai_client")
+async def test_translate_to_english_success(
+    mock_get_client: MagicMock, mock_model_name: MagicMock
+) -> None:
     """英語翻訳が成功するケース"""
-    # aiクライアントのモック設定
-    mock_completion = MagicMock()
-    mock_completion.choices[0].message.content = "This is a translation test."
-    mock_get_client.return_value.chat.completions.create.return_value = mock_completion
+    mock_model_name.return_value = "gemini-2.5-flash"
 
-    # 関数実行
+    mock_response = MagicMock()
+    mock_response.text = "This is a translation test."
+    mock_get_client.return_value.models.generate_content.return_value = mock_response
+
     result = await translate_to_english("これは翻訳テストです")
 
-    # アサーション
     assert result == "This is a translation test."
-    mock_get_client.return_value.chat.completions.create.assert_called_once()
+    mock_get_client.return_value.models.generate_content.assert_called_once()
 
 
 @pytest.mark.asyncio
-@patch("utils.text_utils.get_client")
-async def test_translate_to_english_error(mock_get_client: MagicMock) -> None:
+@patch("utils.text_utils.get_model_name")
+@patch("utils.text_utils._get_genai_client")
+async def test_translate_to_english_error(
+    mock_get_client: MagicMock, mock_model_name: MagicMock
+) -> None:
     """英語翻訳中にエラーが発生するケース"""
-    # aiクライアントのモック設定
-    mock_get_client.return_value.chat.completions.create.side_effect = Exception(
+    mock_model_name.return_value = "gemini-2.5-flash"
+    mock_get_client.return_value.models.generate_content.side_effect = Exception(
         "API error"
     )
 
-    # 関数実行
     result = await translate_to_english("エラーになるテキスト")
 
-    # アサーション
     assert result is None
 
 
 @pytest.mark.asyncio
-@patch("utils.text_utils.get_client")
-async def test_translate_to_japanese_success(mock_get_client: MagicMock) -> None:
+@patch("utils.text_utils.get_model_name")
+@patch("utils.text_utils._get_genai_client")
+async def test_translate_to_japanese_success(
+    mock_get_client: MagicMock, mock_model_name: MagicMock
+) -> None:
     """日本語翻訳が成功するケース"""
-    # aiクライアントのモック設定
-    mock_completion = MagicMock()
-    mock_completion.choices[0].message.content = "これは翻訳されたテキストです。"
-    mock_get_client.return_value.chat.completions.create.return_value = mock_completion
+    mock_model_name.return_value = "gemini-2.5-flash"
 
-    # 関数実行
+    mock_response = MagicMock()
+    mock_response.text = "これは翻訳されたテキストです。"
+    mock_get_client.return_value.models.generate_content.return_value = mock_response
+
     result = await translate_to_japanese("This is a test for translation.")
 
-    # アサーション
     assert result == "これは翻訳されたテキストです。"
-    mock_get_client.return_value.chat.completions.create.assert_called_once()
+    mock_get_client.return_value.models.generate_content.assert_called_once()
 
 
 @pytest.mark.asyncio
-@patch("utils.text_utils.get_client")
-async def test_translate_to_japanese_error(mock_get_client: MagicMock) -> None:
+@patch("utils.text_utils.get_model_name")
+@patch("utils.text_utils._get_genai_client")
+async def test_translate_to_japanese_error(
+    mock_get_client: MagicMock, mock_model_name: MagicMock
+) -> None:
     """日本語翻訳中にエラーが発生するケース"""
-    # aiクライアントのモック設定
-    mock_get_client.return_value.chat.completions.create.side_effect = Exception(
+    mock_model_name.return_value = "gemini-2.5-flash"
+    mock_get_client.return_value.models.generate_content.side_effect = Exception(
         "API error"
     )
 
-    # 関数実行
     result = await translate_to_japanese("Error causing text")
 
-    # アサーション
     assert result is None
+
 
 def test_split_message_short() -> None:
     """短いメッセージは分割されないこと"""
     from utils.text_utils import split_message
+
     text = "Short message"
     chunks = split_message(text)
     assert len(chunks) == 1
@@ -137,6 +145,7 @@ def test_split_message_short() -> None:
 def test_split_message_long() -> None:
     """長いメッセージは指定長で分割されること"""
     from utils.text_utils import split_message
+
     # max_length=10 for easy testing
     text = "123456789012345"
     chunks = split_message(text, max_length=10)
@@ -148,6 +157,7 @@ def test_split_message_long() -> None:
 def test_split_message_with_newlines() -> None:
     """改行がある場合は改行で分割されること"""
     from utils.text_utils import split_message
+
     text = "Line 1\nLine 2\nLine 3"
     # "Line 1" is 6 chars. + newline = 7.
     # max_length=10. It should include "Line 1".
@@ -165,6 +175,7 @@ def test_split_message_with_newlines() -> None:
 def test_split_message_long_no_newlines() -> None:
     """改行がない長いメッセージは強制分割されること"""
     from utils.text_utils import split_message
+
     text = "a" * 25
     chunks = split_message(text, max_length=10)
     assert len(chunks) == 3


### PR DESCRIPTION
<!--
GitHub Copilot コードレビューへの指示： このリポジトリのプルリクエストをレビューしてコメントする場合には日本語で記載してください。
-->

## 概要

#51 の SDK 移行 (OpenAI → google-genai) でソースコードは更新されていたが、テストコードが旧 OpenAI SDK API のままだったため 41 件のテストが失敗していた。全テストを現在の実装に合わせて修正。

## 変更内容

- `tests/conftest.py`: `mock_openai_response` → `mock_genai_response` にリネーム＆GenAI SDK形式に更新
- `tests/test_ai/test_client.py`: `get_client` → `_get_genai_client` に変更、OpenAI固有のテストをGenAI対応に全面書き直し
- `tests/test_ai/test_conversation.py`: OpenAI SDKのインポート/エラー型/API構造を撤去し、新APIに合わせたテストに置換（`sphene.system`/`input_list`/`logs` → `system_prompt`/`history`）
- `tests/test_ai/test_conversation_extensive.py`: モジュールレベル関数（`_handle_api_error`, `_execute_tool_calls`, `_call_genai_with_tools`）のテストに更新
- `tests/test_memory/test_llm_judge.py`: `get_client` → `_get_genai_client`、`chat.completions.create` → `models.generate_content` に更新
- `tests/test_utils/test_text_utils.py`: 同様にGenAI SDK対応に更新

## 影響範囲

- [x] AI (client / conversation / tools)
- [ ] Bot (commands / events / discord_bot)
- [ ] XIVAPI
- [x] Utils (text_utils / channel_config / firestore)
- [ ] Config / 環境変数
- [ ] 依存パッケージ (pyproject.toml)
- [ ] Docker / CI

## テスト

- [x] `uv run python -m pytest` 全件パス (317 passed)
- [x] カバレッジ 86% 以上を維持 (90%)

## 補足

- 削除済み機能（リトライロジック、`_process_images`メソッド等）のテストは除去し、新しく追加された機能（`_call_genai_with_tools`、ドメインフィルタリング等）のテストを追加
- テスト数: 旧320件(41失敗) → 新317件(0失敗)。不要テスト削除分で微減

🤖 Generated with [Claude Code](https://claude.com/claude-code)