### PR TITLE
fix: ツール呼び出しループの上限改善とツールなし最終コール追加

### DIFF
--- a/.claude/instructions/memory-bank/activeContext.md
+++ b/.claude/instructions/memory-bank/activeContext.md
@@ -5,14 +5,23 @@ applyTo: "**"
 
 ## Current State (2026/2)
 
-- 全テスト通過（277件）
+- 全テスト通過（323件）
 - Vertex AI Native SDK (`google-genai`) への完全移行完了。OpenAI互換APIを廃止し、Gemini 3等の最新モデルに完全対応。
 - 環境変数を `GEMINI_MODEL` 形式に統一、`OPENAI_API_KEY` を完全削除。
 - Google検索Grounding機能のサポート開始（`ENABLE_GOOGLE_SEARCH_GROUNDING`）。
 - Discord heartbeat blocking修正済み（`asyncio.to_thread()`）。
 - 記憶機能（Phase 1 + Phase 2）実装済み。
+- ツール呼び出しループの改善済み（上限の環境変数化 + ツールなし最終コール）。
 
 ## Recent Changes
+
+### 2026/2: ツール呼び出しループの改善
+
+複数回のツール呼び出しでラウンド上限に達した際、集めた情報が無駄になり固定エラーメッセージが返される問題を修正。
+
+- **`MAX_TOOL_CALL_ROUNDS`の環境変数化**: ハードコード(`3`)を廃止し、`config.py`で環境変数から注入（デフォルト: `5`）。12-factor原則に準拠。
+- **ツールなし最終コール**: ループ上限到達後、ツールを渡さずに1回追加APIコールを実行。AIがこれまでに集めた全情報を使ってテキスト応答を生成できるようにした。
+- 固定エラー文「処理が複雑すぎて諦めちゃった…」はAPI自体が失敗した場合の最終フォールバックとしてのみ残存。
 
 ### 2026/2: Vertex AI Native SDK (`google-genai`) 完全移行
 

--- a/.claude/instructions/memory-bank/progress.md
+++ b/.claude/instructions/memory-bank/progress.md
@@ -11,6 +11,7 @@ applyTo: "**"
 - uv移行: pyproject.toml + uv.lock による依存管理、CI/Dockerfileのuv対応
 - Discord応答（メンション、名前呼び、リプライ）、スラッシュコマンド
 - Gemini-2.5-flash対話、会話履歴管理、マルチモーダル（画像）
+- ツール呼び出しループ改善: `MAX_TOOL_CALL_ROUNDS`環境変数化（デフォルト5）+ ツールなし最終コール追加
 - Function Calling → XIVAPI v2検索（アイテム・アクション・レシピ・クエスト等、詳細フィルタ対応）
 - 翻訳（国旗リアクション: US/JP）
 - チャンネル管理（全体/限定モード、追加/削除）

--- a/.env.sample
+++ b/.env.sample
@@ -26,6 +26,10 @@ FIRESTORE_COLLECTION_NAME=channel_configs
 # ログレベル設定: DEBUG, INFO, WARNING, ERROR, CRITICAL のいずれか
 LOG_LEVEL=INFO
 
+# === AI会話設定 ===
+# ツール呼び出しの最大ラウンド数（デフォルト: 5）
+# MAX_TOOL_CALL_ROUNDS=5
+
 # === 記憶機能設定 ===
 
 # 短期記憶（チャンネルメッセージバッファ）

--- a/config.py
+++ b/config.py
@@ -38,6 +38,9 @@ FIRESTORE_COLLECTION_NAME: str = str(
     os.getenv("FIRESTORE_COLLECTION_NAME", "channel_configs")
 )
 
+# === AI会話設定 ===
+MAX_TOOL_CALL_ROUNDS: int = int(os.getenv("MAX_TOOL_CALL_ROUNDS", "5"))
+
 # === 記憶機能設定 ===
 
 # 短期記憶（チャンネルメッセージバッファ）


### PR DESCRIPTION
<!--
GitHub Copilot コードレビューへの指示： このリポジトリのプルリクエストをレビューしてコメントする場合には日本語で記載してください。
-->

## 概要

複数回のツール呼び出しでラウンド上限（旧: 3回）に達した際、AIが集めた情報を活かせずハードコードされたエラーメッセージ「処理が複雑すぎて諦めちゃった…😢」が返される問題を修正。

## 変更内容

- `MAX_TOOL_CALL_ROUNDS` を `conversation.py` のハードコード(3)から `config.py` の環境変数注入(デフォルト: 5)に変更
- ツール呼び出しループ上限到達後、**ツールを渡さずに最終APIコール**を1回追加。AIがこれまでに収集した全情報を使ってテキスト応答を生成できるようにした
- 固定エラー文はAPI自体が失敗した場合の最終フォールバックとしてのみ残存

## 影響範囲

- [x] AI (client / conversation / tools)
- [ ] Bot (commands / events / discord_bot)
- [ ] XIVAPI
- [ ] Utils (text_utils / channel_config / firestore)
- [x] Config / 環境変数
- [ ] 依存パッケージ (pyproject.toml)
- [ ] Docker / CI

## テスト

- [x] `uv run python -m pytest` 全件パス (323件)
- [x] `uv run mypy .` 型チェックパス（既存エラーのみ、新規エラーなし）
- [x] カバレッジ 86% 以上を維持 (90%)

## 補足

発生していた問題のログ:
```
ラウンド1: search_recipe("スーパーエテール") → 成功
ラウンド2: search_item("エテール") → 0件
ラウンド3: search_item("エーテル") → 5件
ラウンド4: search_item("マキシエーテル") → 1件 → ループ終了、結果は破棄
→ "処理が複雑すぎて諦めちゃった…😢"
```

修正後は、ラウンド上限到達後もツールなし最終コールでAIが収集済み情報をまとめた応答を返せる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)