### PR TITLE
feat: Vertex AI API呼び出しにリトライ処理（指数バックオフ）を追加

### DIFF
--- a/memory/llm_judge.py
+++ b/memory/llm_judge.py
@@ -5,6 +5,7 @@ import asyncio
 
 import config
 from ai.client import _get_genai_client, get_model_name
+from ai.conversation import _generate_content_with_retry
 from google.genai import types
 from log_utils.logger import logger
 
@@ -51,9 +52,10 @@ class LLMJudge:
         logger.debug(f"LLM Judge呼び出し: model={model_name}")
 
         try:
-            response = client.models.generate_content(
+            response = _generate_content_with_retry(
+                client=client,
                 model=model_name,
-                contents=prompt,
+                contents=[types.Content(role="user", parts=[types.Part.from_text(text=prompt)])],
                 config=types.GenerateContentConfig(
                     temperature=0.1,
                     response_mime_type="application/json", # JSONモードを有効化！

--- a/memory/summarizer.py
+++ b/memory/summarizer.py
@@ -7,6 +7,7 @@ from google.genai import types
 
 import config
 from ai.client import _get_genai_client, get_model_name
+from ai.conversation import _generate_content_with_retry
 from log_utils.logger import logger
 from memory.channel_context import ChannelContext, get_channel_context_store
 from memory.short_term import ChannelMessage
@@ -105,9 +106,10 @@ class Summarizer:
         )
 
         try:
-            response = client.models.generate_content(
+            response = _generate_content_with_retry(
+                client=client,
                 model=model_name,
-                contents=prompt,
+                contents=[types.Content(role="user", parts=[types.Part.from_text(text=prompt)])],
                 config=types.GenerateContentConfig(
                     temperature=0.3,
                     response_mime_type="application/json",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "requests",
     "httpx",
     "google-cloud-aiplatform>=1.137.0",
+    "tenacity>=9.1.4",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -1168,6 +1168,7 @@ dependencies = [
     { name = "openai" },
     { name = "python-dotenv" },
     { name = "requests" },
+    { name = "tenacity" },
 ]
 
 [package.dev-dependencies]
@@ -1190,6 +1191,7 @@ requires-dist = [
     { name = "openai" },
     { name = "python-dotenv" },
     { name = "requests" },
+    { name = "tenacity", specifier = ">=9.1.4" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## 概要

Vertex AI API (Gemini) の呼び出しにおいて、レート制限（429 Too Many Requests / Resource Exhausted）や一時的なサーバーエラー（500/503等）が発生した際、自動的に指数バックオフを用いたリトライを行うように修正しました。

## 変更内容

- **tenacityの導入**: 指数バックオフ付きのリトライ処理を簡潔に実装するため、`tenacity` ライブラリを依存関係に追加しました。
- **共通リトライ関数の実装**: `ai/conversation.py` に `_generate_content_with_retry` 関数を実装しました。この関数は `google.genai.errors.APIError` および `google.api_core.exceptions` の特定のステータスコード（429, 500, 503, 504）に対してリトライを行います。
- **リトライの適用**:
    - `ai/conversation.py`: 会話応答生成および相槌生成に適用。
    - `memory/llm_judge.py`: 自律応答の二次判定処理に適用。
    - `memory/summarizer.py`: 中期記憶（ローリング要約）生成処理に適用。
- **テストの追加**: リトライロジックが期待通りに動作することを確認するテストを `tests/test_ai/test_conversation.py` に追加しました。

## 影響範囲

- [x] AI (client / conversation / tools)
- [ ] Bot (commands / events / discord_bot)
- [ ] XIVAPI
- [ ] Utils (text_utils / channel_config / firestore)
- [ ] Config / 環境変数
- [x] 依存パッケージ (pyproject.toml)
- [ ] Docker / CI

## テスト

- [x] `uv run python -m pytest tests/test_ai/test_conversation.py` パス
- [x] `uv run python -m pytest tests/test_memory/test_llm_judge.py` パス
- [x] `uv run python -m pytest tests/test_memory/test_summarizer.py` パス
- [x] `uv run mypy .` 今回の変更箇所に関する型エラーがないことを確認（既存の他箇所のエラーは残っています）

## 補足

リトライの設定は以下の通りです：
- 最大試行回数: 5回
- 待機時間: 2秒から開始、最大60秒まで指数関数的に増加
