### PR TITLE
fix: build.ymlのバッククォートによるコマンド置換エラーを修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,8 +75,9 @@ jobs:
       # 🤖 AI generated PR title
       - name: Generate PR title with AI
         id: ai-title
+        env:
+          COMMIT_MSG: ${{ steps.last-commit.outputs.message }}
         run: |
-          COMMIT_MSG="${{ steps.last-commit.outputs.message }}"
           IMAGE_TAG="${{ steps.extract-tag.outputs.IMAGE_TAG }}"
           
           # コミットメッセージの改行・特殊文字をエスケープ
@@ -87,8 +88,8 @@ jobs:
           
           # JSONペイロードを構築（jqを使って安全にエスケープ）
           JSON_PAYLOAD=$(jq -n \
-            --arg model "openai/gpt-4.1" \
-            --arg content "GitOpsのデプロイPRタイトルを作って。コミットメッセージ: $ESCAPED_COMMIT_MSG、イメージタグ: $ESCAPED_IMAGE_TAG。はてなブックマークでバズりそうな面白いタイトルを1行で。絵文字も使って！" \
+            --arg model "openai/gpt-5" \
+            --arg content "このリポジトリはgitops用インフラリポジトリ。デプロイPRタイトルを作って。コミットメッセージ: $ESCAPED_COMMIT_MSG、イメージタグ: $ESCAPED_IMAGE_TAG。はてなブックマークでバズりそうな面白いタイトルを1行で。絵文字も使って。" \
             '{
               "model": $model,
               "messages": [
@@ -140,8 +141,9 @@ jobs:
       # 🤖 AI generated PR body
       - name: Generate PR body with AI
         id: ai-body
+        env:
+          COMMIT_MSG: ${{ steps.last-commit.outputs.message }}
         run: |
-          COMMIT_MSG="${{ steps.last-commit.outputs.message }}"
           IMAGE_TAG="${{ steps.extract-tag.outputs.IMAGE_TAG }}"
           BUILD_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           
@@ -152,8 +154,8 @@ jobs:
           
           # JSONペイロードを構築
           JSON_PAYLOAD=$(jq -n \
-            --arg model "openai/gpt-4.1" \
-            --arg content "GitOpsのデプロイPRの説明文をマークダウンで作って。楽しい感じで！\n\nコミット内容: $ESCAPED_COMMIT_MSG\nイメージタグ: $IMAGE_TAG\nビルドURL: $BUILD_URL\n\n以下の情報を含めてね:\n- 🏷️ イメージタグ\n- 📝 変更内容\n- 🔨 ビルドリンク\n- マージボタンを押してもらうお願い\n\n毎回違うテンションで書いて！" \
+            --arg model "openai/gpt-5" \
+            --arg content "このリポジトリはgitopsのインフラリポジトリ。デプロイPRの説明文をマークダウンで作ってください。明るく楽しい、くだけた雰囲気で。\n\nコミット内容: $ESCAPED_COMMIT_MSG\nイメージタグ: $IMAGE_TAG\nビルドURL: $BUILD_URL\n\n以下の情報を含めてね:\n- 🏷️ イメージタグ\n- 📝 変更内容\n- 🔨 ビルドリンク\n- マージボタンを押してもらうお願い\n\n出力はマークダウンの本文だけを出力すること。" \
             '{
               "model": $model,
               "messages": [


### PR DESCRIPTION
<!--
GitHub Copilot コードレビューへの指示： このリポジトリのプルリクエストをレビューしてコメントする場合には日本語で記載してください。
-->

## 概要

コミットメッセージにバッククォート（`` ` ``）が含まれると、`build.yml`の「Generate PR title/body with AI」ステップでbashのコマンド置換として解釈され `command not found` エラーが発生する問題を修正。

## 変更内容

- `COMMIT_MSG`をbashのダブルクォート代入からGitHub Actionsの`env:`ブロックでの環境変数渡しに変更し、シェル解釈を回避
- AIモデルを`openai/gpt-5`に更新
- PRタイトル・本文生成プロンプトを改善

## 影響範囲

- [ ] AI (client / conversation / tools)
- [ ] Bot (commands / events / discord_bot)
- [ ] XIVAPI
- [ ] Utils (text_utils / channel_config / firestore)
- [ ] Config / 環境変数
- [ ] 依存パッケージ (pyproject.toml)
- [x] Docker / CI

## テスト

- [x] `uv run python -m pytest` 全件パス
- [x] `uv run mypy .` 型チェックパス
- [x] カバレッジ 86% 以上を維持

## 補足

- エラー再現例: コミットメッセージに `` `_generate_content_with_retry` `` のようなバッククォート付きテキストが含まれるとビルドが失敗する
- `env:`で渡すことでbashのシェル解釈を完全にバイパスできる

🤖 Generated with [Claude Code](https://claude.com/claude-code)