### PR TITLE
fix: テスト失敗と型ヒントエラーを修正

### DIFF
--- a/ai/tools.py
+++ b/ai/tools.py
@@ -4,13 +4,13 @@ LLMが使用できるツール（関数）の定義を集約するモジュー�
 新しいSDK (google-genai) に対応。
 """
 
-from typing import Callable
+from typing import Any, Callable
 from google.genai import types
 
 from xivapi.client import search_action, search_game_content, search_item, search_recipe
 
 # ツール定義リスト（OpenAI互換形式を維持しつつ、後で変換する）
-TOOL_DEFINITIONS_RAW = [
+TOOL_DEFINITIONS_RAW: list[dict[str, Any]] = [
     {
         "name": "search_item",
         "description": (

--- a/tests/test_ai/test_conversation.py
+++ b/tests/test_ai/test_conversation.py
@@ -182,7 +182,7 @@ def test_input_message_with_images() -> None:
         )
 
         response = sphene.input_message(
-            "この画像は何？", ["https://cdn.discordapp.com/image.jpg"]
+            "この画像は何？", image_urls=["https://cdn.discordapp.com/image.jpg"]
         )
 
         assert response == "画像を確認しました"
@@ -199,7 +199,7 @@ def test_input_message_with_disallowed_image_domain() -> None:
         mock_call.return_value = (True, "テスト応答", [MagicMock()])
 
         response = sphene.input_message(
-            "テスト", ["https://evil.com/image.jpg"]
+            "テスト", image_urls=["https://evil.com/image.jpg"]
         )
 
         # requests.getは呼ばれないこと（ドメインが許可されていない）

--- a/tests/test_ai/test_conversation_genai.py
+++ b/tests/test_ai/test_conversation_genai.py
@@ -38,7 +38,7 @@ def test_input_message_skips_oversize_image() -> None:
 
         mock_call.return_value = (True, "ok", [])
 
-        result = sphene.input_message("hi", [DISCORD_CDN_URL])
+        result = sphene.input_message("hi", image_urls=[DISCORD_CDN_URL])
 
         assert result == "ok"
         mock_get.assert_called_once()
@@ -59,7 +59,7 @@ def test_input_message_skips_non_image_content_type() -> None:
 
         mock_call.return_value = (True, "ok", [])
 
-        result = sphene.input_message("hi", [DISCORD_CDN_URL])
+        result = sphene.input_message("hi", image_urls=[DISCORD_CDN_URL])
 
         assert result == "ok"
         mock_get.assert_called_once()
@@ -81,7 +81,7 @@ def test_input_message_skips_streaming_overflow_without_length() -> None:
 
         mock_call.return_value = (True, "ok", [])
 
-        result = sphene.input_message("hi", [DISCORD_CDN_URL])
+        result = sphene.input_message("hi", image_urls=[DISCORD_CDN_URL])
 
         assert result == "ok"
         mock_get.assert_called_once()
@@ -97,7 +97,7 @@ def test_input_message_skips_disallowed_domain() -> None:
     ) as mock_get, patch("ai.conversation.types.Part.from_bytes") as mock_from_bytes:
         mock_call.return_value = (True, "ok", [])
 
-        result = sphene.input_message("hi", ["https://evil.example.com/img.jpg"])
+        result = sphene.input_message("hi", image_urls=["https://evil.example.com/img.jpg"])
 
         assert result == "ok"
         mock_get.assert_not_called()
@@ -122,7 +122,7 @@ def test_input_message_allows_discord_media_domain() -> None:
 
         mock_call.return_value = (True, "ok", [])
 
-        result = sphene.input_message("hi", [DISCORD_MEDIA_URL])
+        result = sphene.input_message("hi", image_urls=[DISCORD_MEDIA_URL])
 
         assert result == "ok"
         mock_get.assert_called_once()
@@ -150,7 +150,7 @@ def test_input_message_handles_invalid_content_length() -> None:
 
         mock_call.return_value = (True, "ok", [])
 
-        result = sphene.input_message("hi", [DISCORD_CDN_URL])
+        result = sphene.input_message("hi", image_urls=[DISCORD_CDN_URL])
 
         assert result == "ok"
         # Content-Lengthが不正でもクラッシュせず、ストリーミングで読み込まれる

--- a/tests/test_memory/test_summarizer.py
+++ b/tests/test_memory/test_summarizer.py
@@ -401,8 +401,9 @@ class TestSummarizerCallSummarizeLlm:
         summarizer._call_summarize_llm(context, messages)
 
         call_args = mock_client.models.generate_content.call_args
-        prompt = call_args.kwargs["contents"]
-        assert "前回の要約: 前回の要約です" in prompt
+        contents = call_args.kwargs["contents"]
+        prompt_text = contents[0].parts[0].text
+        assert "前回の要約: 前回の要約です" in prompt_text
 
 
 class TestSummarizerApplyResult:


### PR DESCRIPTION
## 概要

6件のテスト失敗と18件の mypy 型エラーを修正。

## 変更内容

- `ai/tools.py`: `TOOL_DEFINITIONS_RAW` に `list[dict[str, Any]]` 型アノテーションを追加（mypy が `Collection[str]` と誤推論していた問題を解消）
- `ai/conversation.py` (`_execute_tool_calls`): `call.name: str | None` の None チェック追加、`call.args: dict | None` を `or {}` でデフォルト化、`result_content` に明示的な型アノテーション追加
- `ai/conversation.py` (line 187): ライブラリ側の `list` 不変性問題に `# type: ignore[arg-type]` を追加
- `tests/test_ai/test_conversation_genai.py`: `input_message("hi", [url])` の 2 番目の位置引数を `image_urls=[url]` キーワード引数に修正
- `tests/test_ai/test_conversation.py`: 同上
- `tests/test_memory/test_summarizer.py`: `contents` が `list[Content]` になったため、`contents[0].parts[0].text` でテキストを取り出してからアサートするよう修正

## 影響範囲

- [x] AI (client / conversation / tools)

## テスト

- [x] `uv run python -m pytest` 全件パス
- [x] `uv run mypy .` 型チェックパス
- [x] カバレッジ 86% 以上を維持

## 補足

Python 3.14 対応の型ヒント記法（`X | Y`、`list[...]`、`dict[str, Any]` 等）を使用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)