### PR TITLE
refactor: AI_PROVIDER 環境変数を廃止（Vertex AI 固定化）

### DIFF
--- a/.claude/instructions/memory-bank/activeContext.md
+++ b/.claude/instructions/memory-bank/activeContext.md
@@ -134,10 +134,10 @@ OpenAI互換エンドポイントの制限（最新モデルの404エラー等�
 
 ### 2026/2: Vertex AI OpenAI互換API対応
 
-`AI_PROVIDER`環境変数（`openai`/`vertex_ai`）でプロバイダーを切り替え可能にした。
+Vertex AI固定構成。`AI_PROVIDER`環境変数は廃止済み。
 
-- `ai/client.py`: シングルトン`client`を廃止、`get_client()`関数に統一。Vertex AI選択時はGCEのWorkload Identity認証（`google.auth.default()`）でトークンを自動取得・リフレッシュ。
-- `config.py`: `AI_PROVIDER`, `VERTEX_AI_PROJECT_ID`, `VERTEX_AI_LOCATION`環境変数を追加。
+- `ai/client.py`: シングルトン`client`を廃止、`get_client()`関数に統一。GCEのWorkload Identity認証（`google.auth.default()`）でトークンを自動取得・リフレッシュ。
+- `config.py`: `VERTEX_AI_PROJECT_ID`, `VERTEX_AI_LOCATION`環境変数で設定。
 - `ai/conversation.py`, `utils/text_utils.py`: クライアント参照を`get_client()`に変更。
 - `pyproject.toml`: `google-auth`を明示的依存に追加。
 - OpenAI互換APIのため、`tools.py`のツール定義やAPIコールパラメータは変更不要。
@@ -174,7 +174,7 @@ requirements.txt/requirements-dev.txt → pyproject.toml + uv.lock。pytest.ini 
 | 2026/2 | システムプロンプトはローカルのみ | k8s configmapマウントで十分 |
 | 2026/2 | `asyncio.to_thread()`で最小修正 | 2ファイル10行で全ブロッキングポイントをカバー。フルasync化は中期候補 |
 | 2026/2 | XIVAPI全パラメータにデフォルト値 | `func(**arguments)`動的呼び出しとの後方互換性維持 |
-| 2026/2 | Vertex AI OpenAI互換API対応 | GCP一本化方針。Workload Identity認証でAPIキー管理不要。`AI_PROVIDER`で切替可能 |
+| 2026/2 | Vertex AI固定化 | GCP一本化方針。Workload Identity認証でAPIキー管理不要。`AI_PROVIDER`環境変数は廃止 |
 
 ## Open Issues
 

--- a/.env.sample
+++ b/.env.sample
@@ -2,10 +2,7 @@ DISCORD_TOKEN=
 BOT_NAME=スフェーン
 COMMAND_GROUP_NAME=sphene
 
-# AIプロバイダー設定: openai または vertex_ai
-AI_PROVIDER=vertex_ai
-
-# Vertex AI設定（AI_PROVIDER=vertex_ai の場合に使用）
+# Vertex AI設定
 # VERTEX_AI_PROJECT_ID=your-gcp-project-id  # 未設定の場合はGCEメタデータから自動取得
 VERTEX_AI_LOCATION=asia-northeast1
 GEMINI_MODEL=google/gemini-2.5-flash

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ COMMAND_GROUP_NAME=sphene  # コマンドグループ名（コードのデフォ
 GEMINI_MODEL=google/gemini-2.5-flash  # 使用するモデル
 
 # Vertex AI設定
-AI_PROVIDER=vertex_ai
 # VERTEX_AI_PROJECT_ID=your-gcp-project-id  # 未設定の場合はGCEメタデータから自動取得
 VERTEX_AI_LOCATION=asia-northeast1
 

--- a/config.py
+++ b/config.py
@@ -9,9 +9,6 @@ LOG_LEVEL: str = str(os.getenv("LOG_LEVEL", "INFO"))
 # ログフォーマット設定（"json" または "text"）
 LOG_FORMAT: str = str(os.getenv("LOG_FORMAT", "json"))
 
-# AIプロバイダー設定（現在は Vertex AI 固定）
-AI_PROVIDER: str = os.getenv("AI_PROVIDER", "vertex_ai")
-
 GEMINI_MODEL: str = os.getenv("GEMINI_MODEL", "google/gemini-2.5-flash")
 
 # Vertex AI設定


### PR DESCRIPTION
## 概要

Vertex AI 以外のプロバイダーを使用する予定がないため、切り替え用の `AI_PROVIDER` 環境変数を廃止する。

## 変更内容

- `config.py`: `AI_PROVIDER` の定義を削除
- `.env.sample`: `AI_PROVIDER=vertex_ai` とコメントを削除、Vertex AI設定のコメントを整理
- `README.md`: `AI_PROVIDER=vertex_ai` 行を削除
- `.claude/instructions/memory-bank/activeContext.md`: `AI_PROVIDER` 廃止済みの記述に更新

## 影響範囲

- [x] Config / 環境変数

## テスト

- [ ] `uv run python -m pytest` 全件パス
- [ ] `uv run mypy .` 型チェックパス
- [ ] カバレッジ 86% 以上を維持

## 補足

`ai/client.py` はもともと `AI_PROVIDER` を参照していないため変更不要。