### PR TITLE
fix: ChannelContextStore のプライベートアクセスをスレッドセーフなメソッドに置き換え

### DIFF
--- a/bot/discord_bot.py
+++ b/bot/discord_bot.py
@@ -99,7 +99,7 @@ class SpheneBot:
                 store = get_channel_context_store()
                 buffer = get_channel_buffer()
                 summarizer = get_summarizer()
-                for channel_id, ctx in store._contexts.items():
+                for channel_id, ctx in store.get_all_contexts().items():
                     if ctx.should_summarize_by_time():
                         recent = buffer.get_recent_messages(channel_id, limit=20)
                         summarizer.maybe_summarize(channel_id, recent)

--- a/memory/channel_context.py
+++ b/memory/channel_context.py
@@ -93,6 +93,10 @@ class ChannelContextStore:
     def __init__(self) -> None:
         self._contexts: dict[int, ChannelContext] = {}
 
+    def get_all_contexts(self) -> dict[int, ChannelContext]:
+        """全コンテキストのコピーを返す（スレッドセーフ）"""
+        return dict(self._contexts)
+
     def get_context(self, channel_id: int) -> ChannelContext:
         """チャンネルコンテキストを取得する（なければ新規作成）"""
         if channel_id in self._contexts:


### PR DESCRIPTION
## 概要

`bot/discord_bot.py` の時間ベース要約チェックで `store._contexts` へ直接アクセスしていた箇所を、パブリックメソッド `get_all_contexts()` 経由に変更した。

## 変更内容

- `ChannelContextStore.get_all_contexts()` メソッドを追加（`dict(self._contexts)` のコピーを返す）
- `discord_bot.py` の `store._contexts.items()` を `store.get_all_contexts().items()` に変更

## 影響範囲

- [ ] AI (client / conversation / tools)
- [x] Bot (commands / events / discord_bot)
- [ ] XIVAPI
- [ ] Utils (text_utils / channel_config / firestore)
- [ ] Config / 環境変数
- [ ] 依存パッケージ (pyproject.toml)
- [ ] Docker / CI

## テスト

- [x] `uv run python -m pytest` 全件パス
- [ ] `uv run mypy .` 型チェックパス
- [x] カバレッジ 86% 以上を維持

## 補足

イテレーション中に別スレッドが `_contexts` 辞書を変更すると `RuntimeError: dictionary changed size during iteration` が発生するリスクがあった。`dict()` でコピーを返すことでスレッドセーフに対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)