### PR TITLE
fix: ログ文言を実態に合わせた表現に修正

### DIFF
--- a/bot/events.py
+++ b/bot/events.py
@@ -599,8 +599,8 @@ async def _handle_on_ready(
     else:
         logger.error("Discordボットのユーザー情報を取得できませんでした")
 
-    # 各ギルドの設定ファイルを初期化
-    logger.info("ギルドごとのチャンネル設定ファイルを初期化")
+    # 各ギルドのチャンネル設定を初期化
+    logger.info("ギルドごとのチャンネル設定を初期化")
     for guild in bot.guilds:
         logger.info(f"ギルド {guild.name} (ID: {guild.id}) の設定をチェック")
         try:

--- a/utils/channel_config.py
+++ b/utils/channel_config.py
@@ -67,7 +67,7 @@ class ChannelConfigManager:
         guild_id = str(guild_id)  # 文字列に変換
 
         if guild_id not in self.guild_configs:
-            logger.info(f"ギルドID {guild_id} の設定を新規作成")
+            logger.info(f"ギルドID {guild_id} の設定インスタンスをメモリ上に作成")
             self.guild_configs[guild_id] = ChannelConfig(
                 guild_id=guild_id, debug_mode=self.debug_mode
             )


### PR DESCRIPTION
## 概要

Firestoreモードで起動したときのログに「ファイル」という表現が含まれており、ローカルファイルを操作しているかのような誤解を招いていたため修正。

## 変更内容

- `bot/events.py`: コメント・ログの「設定ファイルを初期化」→「チャンネル設定を初期化」
- `utils/channel_config.py`: ログの「設定を新規作成」→「設定インスタンスをメモリ上に作成」

## 影響範囲

<!-- 変更が影響するモジュール・機能にチェック -->

- [ ] AI (client / conversation / tools)
- [x] Bot (commands / events / discord_bot)
- [ ] XIVAPI
- [x] Utils (text_utils / channel_config / firestore)
- [ ] Config / 環境変数
- [ ] 依存パッケージ (pyproject.toml)
- [ ] Docker / CI

## テスト

- [x] `uv run python -m pytest` 全件パス
- [x] `uv run mypy .` 型チェックパス
- [x] カバレッジ 86% 以上を維持

## 補足

ログ文言のみの変更のため、動作への影響はなし。