### PR TITLE
feat: INSTANCE_NAME 環境変数の導入とマルチテナント識別子の一元化

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,6 +9,11 @@ LOG_LEVEL: str = str(os.getenv("LOG_LEVEL", "INFO"))
 # ログフォーマット設定（"json" または "text"）
 LOG_FORMAT: str = str(os.getenv("LOG_FORMAT", "json"))
 
+# インスタンス識別子（マルチテナント識別のため必須）
+INSTANCE_NAME: str = os.getenv("INSTANCE_NAME", "")
+if not INSTANCE_NAME:
+    raise ValueError("INSTANCE_NAME is required")
+
 GEMINI_MODEL: str = os.getenv("GEMINI_MODEL", "google/gemini-2.5-flash")
 
 # Vertex AI設定
@@ -21,7 +26,7 @@ ENABLE_GOOGLE_SEARCH_GROUNDING: bool = (
 
 DISCORD_TOKEN: str = str(os.getenv("DISCORD_TOKEN"))
 BOT_NAME: str = str(os.getenv("BOT_NAME", "アサヒ"))
-COMMAND_GROUP_NAME: str = str(os.getenv("COMMAND_GROUP_NAME", "asahi"))
+COMMAND_GROUP_NAME: str = str(os.getenv("COMMAND_GROUP_NAME", INSTANCE_NAME))
 SYSTEM_PROMPT_FILENAME: str = str(os.getenv("SYSTEM_PROMPT_FILENAME", "system.txt"))
 
 # ストレージタイプ（local または firestore）
@@ -30,8 +35,8 @@ STORAGE_TYPE: str = str(os.getenv("STORAGE_TYPE", "local"))
 # システムプロンプトのファイルパス
 SYSTEM_PROMPT_PATH: str = str(os.getenv("SYSTEM_PROMPT_PATH", "storage/system.txt"))
 
-# Firestoreネームスペース（マルチテナント対応、空=プレフィックスなし）
-FIRESTORE_NAMESPACE: str = os.getenv("FIRESTORE_NAMESPACE", "")
+# Firestoreネームスペース（マルチテナント対応）
+FIRESTORE_NAMESPACE: str = os.getenv("FIRESTORE_NAMESPACE", INSTANCE_NAME)
 
 
 def get_collection_name(base_name: str) -> str:

--- a/log_utils/logger.py
+++ b/log_utils/logger.py
@@ -70,4 +70,4 @@ def setup_logger(name: str = "sphene") -> logging.Logger:
 
 
 # デフォルトのロガーインスタンスを作成
-logger = setup_logger()
+logger = setup_logger(config.INSTANCE_NAME)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,9 @@
 """pytestの共通設定と共通fixturesの定義"""
 
+import os
+
+os.environ.setdefault("INSTANCE_NAME", "test-bot")
+
 from typing import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -15,6 +19,7 @@ def mock_env_vars(monkeypatch: MonkeyPatch) -> dict[str, str]:
         "OPENAI_API_KEY": "test-api-key",
         "DISCORD_TOKEN": "test-discord-token",
         "BOT_NAME": "テストボット",
+        "INSTANCE_NAME": "test-bot",
         "COMMAND_GROUP_NAME": "test",
         "DENIED_CHANNEL_IDS": "123456789,987654321",  # 禁止リストとして扱うチャンネルID
         "LOG_LEVEL": "DEBUG",  # テスト時はDEBUGレベルで詳細に確認

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,9 @@
 """config.py のテスト"""
 
+import os
 from unittest.mock import patch
+
+import pytest
 
 from config import get_collection_name
 
@@ -26,3 +29,63 @@ class TestGetCollectionName:
         """開発環境用のネームスペースでも正しく動作する"""
         with patch("config.FIRESTORE_NAMESPACE", "dev"):
             assert get_collection_name("channel_configs") == "dev_channel_configs"
+
+
+class TestInstanceName:
+    """INSTANCE_NAME / FIRESTORE_NAMESPACE / COMMAND_GROUP_NAME のテスト"""
+
+    def test_firestore_namespace_defaults_to_instance_name(self):
+        """FIRESTORE_NAMESPACE 未設定時は INSTANCE_NAME がデフォルト値"""
+        env = {k: v for k, v in os.environ.items() if k != "FIRESTORE_NAMESPACE"}
+        env["INSTANCE_NAME"] = "mybot"
+        with patch("dotenv.load_dotenv"):
+            with patch.dict(os.environ, env, clear=True):
+                import importlib
+
+                import config as cfg
+
+                importlib.reload(cfg)
+                assert cfg.FIRESTORE_NAMESPACE == "mybot"
+
+    def test_firestore_namespace_explicit_value_takes_precedence(self):
+        """FIRESTORE_NAMESPACE を明示的に設定した場合はその値が優先される"""
+        with patch.dict(os.environ, {"INSTANCE_NAME": "mybot", "FIRESTORE_NAMESPACE": "custom"}, clear=False):
+            import importlib
+
+            import config as cfg
+
+            importlib.reload(cfg)
+            assert cfg.FIRESTORE_NAMESPACE == "custom"
+
+    def test_command_group_name_defaults_to_instance_name(self):
+        """COMMAND_GROUP_NAME 未設定時は INSTANCE_NAME がデフォルト値"""
+        with patch.dict(os.environ, {"INSTANCE_NAME": "mybot"}, clear=False):
+            import importlib
+
+            import config as cfg
+
+            os.environ.pop("COMMAND_GROUP_NAME", None)
+            importlib.reload(cfg)
+            assert cfg.COMMAND_GROUP_NAME == "mybot"
+
+    def test_command_group_name_explicit_value_takes_precedence(self):
+        """COMMAND_GROUP_NAME を明示的に設定した場合はその値が優先される"""
+        with patch.dict(os.environ, {"INSTANCE_NAME": "mybot", "COMMAND_GROUP_NAME": "custom_cmd"}, clear=False):
+            import importlib
+
+            import config as cfg
+
+            importlib.reload(cfg)
+            assert cfg.COMMAND_GROUP_NAME == "custom_cmd"
+
+    def test_missing_instance_name_raises_value_error(self):
+        """INSTANCE_NAME 未設定時に ValueError が発生する"""
+        env_without_instance = {k: v for k, v in os.environ.items() if k != "INSTANCE_NAME"}
+        with patch("dotenv.load_dotenv"):
+            with patch.dict(os.environ, env_without_instance, clear=True):
+                import importlib
+
+                import config as cfg
+
+                with pytest.raises(ValueError, match="INSTANCE_NAME is required"):
+                    importlib.reload(cfg)


### PR DESCRIPTION
<!--
GitHub Copilot コードレビューへの指示： このリポジトリのプルリクエストをレビューしてコメントする場合には日本語で記載してください。
-->

## 概要

マルチテナント運用で複数ボットプロセスが同一 GCP プロジェクトにログを送信する際、`jsonPayload.logger="sphene"` という固定文字列ではどのボットのログか判別できない問題を解消する。`INSTANCE_NAME` を必須 env var として導入し、関連識別子のデフォルト値を一元化する。

closes #84

## 変更内容

- `config.py`: `INSTANCE_NAME` を必須 env var として追加（未設定時に `ValueError` を raise）
- `config.py`: `COMMAND_GROUP_NAME` / `FIRESTORE_NAMESPACE` のデフォルト値を `"asahi"` / `""` から `INSTANCE_NAME` に変更
- `log_utils/logger.py`: `logger` 名を `config.INSTANCE_NAME` に変更（JSON ログの `logger` フィールドがインスタンス識別子になる）
- `tests/conftest.py`: モジュールロード前に `INSTANCE_NAME=test-bot` を設定、`mock_env_vars` fixture にも追加
- `tests/test_config.py`: `TestInstanceName` クラスを 5 テストケースで追加

## 影響範囲

<!-- 変更が影響するモジュール・機能にチェック -->

- [ ] AI (client / conversation / tools)
- [ ] Bot (commands / events / discord_bot)
- [ ] XIVAPI
- [ ] Utils (text_utils / channel_config / firestore)
- [x] Config / 環境変数
- [ ] 依存パッケージ (pyproject.toml)
- [ ] Docker / CI

## テスト

- [x] `uv run python -m pytest` 全件パス（既存の 2 件の失敗は変更前から存在）
- [x] `uv run mypy .` 型チェックパス
- [x] カバレッジ 86% 以上を維持

## 補足

**破壊的変更あり**: `INSTANCE_NAME` は必須 env var のため、既存の `.env` や起動スクリプトに追加が必要。