### PR TITLE
fix: TestEventsExtensive で re.split が MagicMock を受け取って失敗する問題を修正

### DIFF
--- a/tests/test_bot/test_events_extensive.py
+++ b/tests/test_bot/test_events_extensive.py
@@ -93,6 +93,7 @@ class TestEventsExtensive:
         mock_split.return_value = ["Chunk 1", "Chunk 2"]
 
         message = MagicMock()
+        message.content = ""
         message.channel.send = AsyncMock()
 
         await process_conversation(message, "question", is_reply=True)


### PR DESCRIPTION
## 概要

`TestEventsExtensive.test_process_conversation_chunking` において、`message.content` がデフォルトの `MagicMock` オブジェクトのままだったため、キーワード抽出処理内の `re.split` で `TypeError` が発生していた問題を修正しました。

## 変更内容

- `tests/test_bot/test_events_extensive.py` 内の `test_process_conversation_chunking` で `message.content = ""` を追加。

## 影響範囲

- [ ] AI (client / conversation / tools)
- [x] Bot (commands / events / discord_bot)
- [ ] XIVAPI
- [ ] Utils (text_utils / channel_config / firestore)
- [ ] Config / 環境変数
- [ ] 依存パッケージ (pyproject.toml)
- [ ] Docker / CI

## テスト

- [x] `uv run python -m pytest` 全件パス
- [x] `uv run mypy .` 型チェックパス
- [x] カバレッジ 86% 以上を維持 (87%を確認)
