### PR TITLE
refactor: 不要なスラッシュコマンド (reset/reload_prompt/updatelist) を削除 (#83)

### DIFF
--- a/ai/conversation.py
+++ b/ai/conversation.py
@@ -328,17 +328,6 @@ def generate_proactive_message(
         return None
 
 
-def reload_system_prompt(fail_on_error: bool = False) -> bool:
-    """システムプロンプトを強制的に再読み込みする"""
-    try:
-        load_system_prompt(force_reload=True, fail_on_error=fail_on_error)
-        return True
-    except Exception as e:
-        logger.error(f"プロンプト再読み込みエラー: {e}", exc_info=True)
-        if fail_on_error:
-            raise
-        return False
-
 # チャンネルごとの会話インスタンスを保持する辞書
 channel_conversations: defaultdict[str, Sphene] = defaultdict(
     lambda: Sphene(system_setting=load_system_prompt())

--- a/bot/commands.py
+++ b/bot/commands.py
@@ -2,12 +2,7 @@ import discord
 from discord import app_commands, ui
 
 import config
-from ai.conversation import (
-    Sphene,
-    load_system_prompt,
-    reload_system_prompt,
-    channel_conversations,
-)
+from ai.conversation import channel_conversations
 from log_utils.logger import logger
 from utils.channel_config import ChannelConfigManager
 
@@ -416,87 +411,6 @@ async def cmd_clear_channels(interaction: discord.Interaction) -> None:
     )
 
 
-async def cmd_update_list(interaction: discord.Interaction) -> None:
-    """チャンネルリストを手動で保存するコマンドを処理する
-
-    Args:
-        interaction: インタラクションオブジェクト
-    """
-    if not interaction.guild:
-        await interaction.response.send_message(
-            "❌ このコマンドはサーバー内でのみ使用できます"
-        )
-        return
-
-    # ギルド固有の設定を取得
-    guild_id = interaction.guild.id
-    channel_config = config_manager.get_config(guild_id)
-
-    success = channel_config.save_config()
-    list_name = channel_config.get_list_display_name()
-
-    if success:
-        # 設定保存後にリストを再読み込み
-        channel_config.load_config()
-        await interaction.response.send_message(
-            f"✅ {list_name}を保存しました！\n" f"保存先: {channel_config.storage_type}"
-        )
-    else:
-        await interaction.response.send_message(f"❌ {list_name}の保存に失敗しました")
-
-
-async def cmd_reset_conversation(interaction: discord.Interaction) -> None:
-    """会話履歴リセットコマンドを処理する
-
-    Args:
-        interaction: インタラクションオブジェクト
-    """
-    if interaction.channel_id is None:
-        await interaction.response.send_message("❌ チャンネル情報の取得に失敗しました")
-        return
-
-    channel_id = str(interaction.channel_id)
-
-    if channel_id in channel_conversations:
-        channel_conversations[channel_id] = Sphene(system_setting=load_system_prompt())
-        await interaction.response.send_message(
-            "🔄 このチャンネルの会話履歴をリセットしたよ！また一から話そうね！"
-        )
-        logger.info(f"チャンネルID {channel_id} の会話履歴を手動リセット")
-    else:
-        await interaction.response.send_message(
-            "🤔 このチャンネルではまだ話したことがないみたいだね！これから仲良くしようね！"
-        )
-
-
-async def cmd_reload_prompt(interaction: discord.Interaction) -> None:
-    """システムプロンプト再読み込みコマンドを処理する
-
-    Args:
-        interaction: インタラクションオブジェクト
-    """
-    # 応答を遅延送信（処理に時間がかかる可能性があるため）
-    await interaction.response.defer(ephemeral=True)
-
-    # 手動再読み込みではfail_on_error=Falseを指定（エラー時にボットを停止しない）
-    success = reload_system_prompt(fail_on_error=False)
-
-    if success:
-        logger.info(
-            f"システムプロンプト再読み込み成功（実行者: {interaction.user.name}）"
-        )
-        await interaction.followup.send(
-            "✅ システムプロンプトを再読み込みしました！\n"
-            f"プロンプトファイル: **{config.SYSTEM_PROMPT_FILENAME}**"
-        )
-    else:
-        logger.error(
-            f"システムプロンプト再読み込み失敗（実行者: {interaction.user.name}）"
-        )
-        await interaction.followup.send(
-            "❌ システムプロンプトの再読み込みに失敗しました。ログを確認してください。"
-        )
-
 
 async def cmd_translation(interaction: discord.Interaction) -> None:
     """翻訳機能の有効/無効切替コマンドを処理する
@@ -614,30 +528,6 @@ def setup_commands(bot: discord.Client) -> app_commands.Group:
     @app_commands.checks.has_permissions(administrator=True)
     async def clear_channels_command(interaction: discord.Interaction) -> None:
         await cmd_clear_channels(interaction)
-
-    # チャンネルリスト保存コマンド
-    @command_group.command(
-        name="updatelist",
-        description="チャンネルリストと評価モードを手動で保存します",
-    )
-    @app_commands.checks.has_permissions(administrator=True)
-    async def update_list_command(interaction: discord.Interaction) -> None:
-        await cmd_update_list(interaction)
-
-    # リセットコマンド
-    @command_group.command(
-        name="reset", description="このチャンネルの会話履歴をリセットします"
-    )
-    async def reset_conversation_command(interaction: discord.Interaction) -> None:
-        await cmd_reset_conversation(interaction)
-
-    # システムプロンプト再読み込みコマンド
-    @command_group.command(
-        name="reload_prompt", description="システムプロンプトを再読み込みします"
-    )
-    @app_commands.checks.has_permissions(administrator=True)
-    async def reload_prompt_command(interaction: discord.Interaction) -> None:
-        await cmd_reload_prompt(interaction)
 
     # 翻訳機能設定コマンド
     @command_group.command(

--- a/tests/test_ai/test_conversation_extensive.py
+++ b/tests/test_ai/test_conversation_extensive.py
@@ -19,7 +19,6 @@ from ai.conversation import (
     _handle_api_error,
     cleanup_expired_conversations,
     load_system_prompt,
-    reload_system_prompt,
     channel_conversations,
     _prompt_cache,
 )
@@ -52,27 +51,6 @@ class TestConversationExtensive:
         p3 = load_system_prompt(force_reload=True)
         assert p3 == "Custom Prompt"
         assert mock_load_local.call_count == 2
-
-    @patch("ai.conversation._load_prompt_from_local")
-    def test_reload_system_prompt_success(self, mock_load_local):
-        """プロンプト再読み込み成功テスト"""
-        mock_load_local.return_value = "Reloaded Prompt"
-        result = reload_system_prompt()
-        assert result is True
-        assert load_system_prompt() == "Reloaded Prompt"
-
-    @patch("ai.conversation.load_system_prompt")
-    def test_reload_system_prompt_failure(self, mock_load_prompt):
-        """プロンプト再読み込み失敗テスト"""
-        mock_load_prompt.side_effect = Exception("Load Error")
-
-        # fail_on_error=False
-        result = reload_system_prompt(fail_on_error=False)
-        assert result is False
-
-        # fail_on_error=True
-        with pytest.raises(Exception):
-            reload_system_prompt(fail_on_error=True)
 
     def test_trim_conversation_history_safety(self):
         """トリミング時の安全な切断ポイントのテスト"""

--- a/tests/test_bot/test_channel_commands.py
+++ b/tests/test_bot/test_channel_commands.py
@@ -15,7 +15,6 @@ from bot.commands import (
     cmd_list_channels,
     cmd_mode,
     cmd_remove_channel,
-    cmd_update_list,
 )
 
 
@@ -294,75 +293,6 @@ class TestChannelCommands:
 
     @pytest.mark.asyncio
     @patch("bot.commands.config_manager")
-    async def test_update_list_command_success(self, mock_config_manager):
-        """チャンネルリスト保存コマンドのテスト（成功）"""
-        # モックguild設定
-        mock_guild = MagicMock()
-        mock_guild.id = 123456
-
-        # モックチャンネル設定
-        mock_channel_config = MagicMock()
-        mock_channel_config.save_config.return_value = True
-        mock_channel_config.get_list_display_name.return_value = "拒否チャンネルリスト"
-        mock_channel_config.storage_type = "local"
-
-        # マネージャーからチャンネル設定を返すようにセット
-        mock_config_manager.get_config.return_value = mock_channel_config
-
-        # インタラクションのモック
-        interaction = MagicMock()
-        interaction.response.send_message = AsyncMock()
-        interaction.guild = mock_guild
-
-        # コマンド実行
-        await cmd_update_list(interaction)
-
-        # アサーション
-        mock_config_manager.get_config.assert_called_once_with(mock_guild.id)
-        mock_channel_config.save_config.assert_called_once()
-        interaction.response.send_message.assert_called_once()
-
-        # 成功メッセージが表示されていることを確認
-        args, kwargs = interaction.response.send_message.call_args
-        assert "✅" in args[0]
-        assert "保存しました" in args[0]
-
-    @pytest.mark.asyncio
-    @patch("bot.commands.config_manager")
-    async def test_update_list_command_failure(self, mock_config_manager):
-        """チャンネルリスト保存コマンドのテスト（失敗）"""
-        # モックguild設定
-        mock_guild = MagicMock()
-        mock_guild.id = 123456
-
-        # モックチャンネル設定
-        mock_channel_config = MagicMock()
-        mock_channel_config.save_config.return_value = False
-        mock_channel_config.get_list_display_name.return_value = "拒否チャンネルリスト"
-
-        # マネージャーからチャンネル設定を返すようにセット
-        mock_config_manager.get_config.return_value = mock_channel_config
-
-        # インタラクションのモック
-        interaction = MagicMock()
-        interaction.response.send_message = AsyncMock()
-        interaction.guild = mock_guild
-
-        # コマンド実行
-        await cmd_update_list(interaction)
-
-        # アサーション
-        mock_config_manager.get_config.assert_called_once_with(mock_guild.id)
-        mock_channel_config.save_config.assert_called_once()
-        interaction.response.send_message.assert_called_once()
-
-        # 失敗メッセージが表示されていることを確認
-        args, kwargs = interaction.response.send_message.call_args
-        assert "❌" in args[0]
-        assert "失敗" in args[0]
-
-    @pytest.mark.asyncio
-    @patch("bot.commands.config_manager")
     async def test_commands_without_guild(self, mock_config_manager):
         """ギルドなしの場合のエラーメッセージテスト"""
         # インタラクションのモック（guild=Noneに設定）
@@ -375,10 +305,9 @@ class TestChannelCommands:
         await cmd_add_channel(interaction)
         await cmd_remove_channel(interaction)
         await cmd_clear_channels(interaction)
-        await cmd_update_list(interaction)
 
         # 各コマンドで同じエラーメッセージが表示されていることを確認
-        assert interaction.response.send_message.call_count == 5
-        for i in range(5):
+        assert interaction.response.send_message.call_count == 4
+        for i in range(4):
             args, kwargs = interaction.response.send_message.call_args_list[i]
             assert "サーバー内でのみ使用できます" in args[0]

--- a/tests/test_bot/test_commands.py
+++ b/tests/test_bot/test_commands.py
@@ -8,7 +8,6 @@ from discord import app_commands
 import config
 from bot.commands import (
     cmd_list_channels,
-    cmd_reset_conversation,
     handle_command_error,
     setup_commands,
 )
@@ -92,53 +91,6 @@ async def test_cmd_list_channels_no_restrictions(
         assert "全てのチャンネルで発言可能" in args
 
 
-@pytest.mark.asyncio
-async def test_cmd_reset_conversation(mock_discord_interaction: MagicMock) -> None:
-    """会話履歴リセットコマンドのテスト"""
-    # チャンネルIDを設定
-    channel_id = str(mock_discord_interaction.channel_id)
-
-    # channel_conversationsのモック
-    mock_conversations = {channel_id: MagicMock()}
-    with patch("bot.commands.channel_conversations", mock_conversations), patch(
-        "bot.commands.load_system_prompt"
-    ) as mock_load_prompt, patch("bot.commands.Sphene") as mock_sphene_cls:
-        mock_load_prompt.return_value = "テストシステムプロンプト"
-        mock_sphene = MagicMock()
-        mock_sphene_cls.return_value = mock_sphene
-
-        # コマンド実行 - 既存の会話がある場合
-        await cmd_reset_conversation(mock_discord_interaction)
-
-        # 新しいSpheneインスタンスが作成されたか
-        mock_sphene_cls.assert_called_once_with(
-            system_setting=mock_load_prompt.return_value
-        )
-
-        # 会話がリセットされたか
-        assert mock_conversations[channel_id] == mock_sphene
-
-        # レスポンスが送信されたか
-        mock_discord_interaction.response.send_message.assert_called_once()
-        args = mock_discord_interaction.response.send_message.call_args[0][0]
-        assert "会話履歴をリセットしたよ" in args
-
-
-@pytest.mark.asyncio
-async def test_cmd_reset_conversation_no_history(
-    mock_discord_interaction: MagicMock,
-) -> None:
-    """履歴がない場合の会話リセットテスト"""
-    # 空の会話辞書でモック
-    with patch("bot.commands.channel_conversations", {}):
-        # コマンド実行 - 既存の会話がない場合
-        await cmd_reset_conversation(mock_discord_interaction)
-
-        # 適切なレスポンスが送信されたか
-        mock_discord_interaction.response.send_message.assert_called_once()
-        args = mock_discord_interaction.response.send_message.call_args[0][0]
-        assert "まだ話したことがないみたいだね" in args
-
 
 @pytest.mark.asyncio
 async def test_handle_command_error_missing_permissions(
@@ -188,4 +140,6 @@ def test_setup_commands() -> None:
     # コマンドが追加されたか
     command_names = [cmd.name for cmd in command_group.commands]
     assert "channels" in command_names
-    assert "reset" in command_names
+    assert "reset" not in command_names
+    assert "reload_prompt" not in command_names
+    assert "updatelist" not in command_names

--- a/tests/test_bot/test_commands_extensive.py
+++ b/tests/test_bot/test_commands_extensive.py
@@ -16,7 +16,6 @@ from bot.commands import (
     ClearConfirmView,
     cmd_list_channels,
     cmd_remove_channel,
-    cmd_reload_prompt,
     handle_command_error,
     _format_channel_info,
 )
@@ -134,24 +133,6 @@ class TestCommandsExtensive:
         
         interaction.response.send_message.assert_called_once()
         assert "削除に失敗しました" in interaction.response.send_message.call_args[0][0]
-
-    @pytest.mark.asyncio
-    @patch("bot.commands.reload_system_prompt")
-    async def test_cmd_reload_prompt_success_failure(self, mock_reload):
-        """プロンプト再読み込みコマンドのテスト"""
-        interaction = AsyncMock()
-        
-        # 成功ケース
-        mock_reload.return_value = True
-        await cmd_reload_prompt(interaction)
-        args, _ = interaction.followup.send.call_args
-        assert "再読み込みしました" in args[0]
-        
-        # 失敗ケース
-        mock_reload.return_value = False
-        await cmd_reload_prompt(interaction)
-        args, _ = interaction.followup.send.call_args
-        assert "失敗しました" in args[0]
 
     def test_format_channel_info_edge_cases(self):
         """チャンネル情報の整形エッジケーステスト"""


### PR DESCRIPTION
## 概要

Issue #83 に対応。現在の設計では不要になった3つのスラッシュコマンドとその実装を一括削除する。

## 変更内容

- `reset` コマンド削除: 会話リセット機能は運用上不要
- `reload_prompt` コマンド削除: プロンプト再読み込みはデプロイ時に対応すべきこと
- `updatelist` コマンド削除: `addlist`/`removelist` が内部で `save_config()` を自動呼び出すため冗長
- `ai/conversation.py` の `reload_system_prompt()` 関数を削除
- 上記に紐づくテストを削除・修正

## 影響範囲

<!-- 変更が影響するモジュール・機能にチェック -->

- [ ] AI (client / conversation / tools)
- [x] Bot (commands / events / discord_bot)
- [ ] XIVAPI
- [ ] Utils (text_utils / channel_config / firestore)
- [ ] Config / 環境変数
- [ ] 依存パッケージ (pyproject.toml)
- [ ] Docker / CI

## テスト

- [x] `uv run python -m pytest` 全件パス（既存の失敗1件は事前から存在する無関係バグ）
- [x] `uv run mypy .` 型チェックパス
- [x] カバレッジ 83%（変更前と同値・既存テストスイート水準を維持）

## 補足

- `channel_conversations` は `bot/events.py` で引き続き使用中のため残存
- カバレッジが 86% を下回っているが、これは変更前から同値であり本 PR による退行ではない