### PR TITLE
fix: short_ack の相槌が一語になりすぎる問題を修正

### DIFF
--- a/ai/conversation.py
+++ b/ai/conversation.py
@@ -229,8 +229,8 @@ def generate_short_ack(channel_context: str, trigger_message: str) -> str | None
 
         instruction = (
             f"{system_prompt}\n\n"
-            f"以下の会話の流れを読んで、一言の自然な相槌を返してね。"
-            f"長い説明は不要、短く自然に。\n\n"
+            f"以下の会話の流れを読んで、短い自然な相槌を返してね。"
+            f"1〜2文程度で、感情や共感を少し込めてもOK。長い説明は不要。\n\n"
             f"--- チャンネルの直近の会話 ---\n{channel_context}\n---"
         )
 


### PR DESCRIPTION
## 概要

`generate_short_ack()` のシステムプロンプトで「一言の自然な相槌」と指定していたため、
LLM がリテラルに一語（「あ」「へぇ」）しか返さない問題を修正。

## 変更内容

- `ai/conversation.py`: short_ack 生成プロンプトを調整
  - 「一言の」→「短い」に変更（一語制限を撤廃）
  - 「1〜2文程度で、感情や共感を少し込めてもOK」を追加
  - 「長い説明は不要」は維持（長文化を防ぐ）

**Before:** 「あ」「へぇ」「そっか」
**After:** 「わかる〜！いいじゃん！」「へぇ、それおもしろいね」

## 影響範囲

- [x] AI (client / conversation / tools)
- [ ] Bot (commands / events / discord_bot)
- [ ] XIVAPI
- [ ] Utils (text_utils / channel_config / firestore)
- [ ] Config / 環境変数
- [ ] 依存パッケージ (pyproject.toml)
- [ ] Docker / CI

## テスト

- [x] `uv run python -m pytest` 全件パス（26件）
- [ ] `uv run mypy .` 型チェックパス
- [x] カバレッジ 86% 以上を維持

## 補足

`max_output_tokens=100` は変更なし。1〜2文なら十分な余裕がある。